### PR TITLE
Fix: Add nanonext namespace prefixes in worker code (#30)

### DIFF
--- a/R/async_worker.R
+++ b/R/async_worker.R
@@ -37,12 +37,11 @@ worker_init <- function(pub_address) {
   logger::log_info("Worker initializing with publisher at {pub_address}")
 
   # Create subscriber socket
-  # Note: When used in crew workers, nanonext package loaded via packages parameter
-  # so we can call nano() directly without namespace prefix
-  socket <- nano("sub", dial = pub_address)
+  # Note: Always use nanonext:: prefix to ensure function is found in worker
+  socket <- nanonext::nano("sub", dial = pub_address)
 
   # Subscribe to all messages
-  subscribe(socket, "")
+  nanonext::subscribe(socket, "")
 
   # Wait briefly for connection
   Sys.sleep(0.1)
@@ -94,7 +93,7 @@ worker_init <- function(pub_address) {
 #' @export
 worker_check_updates <- function(worker_state) {
   # Non-blocking receive
-  result <- recv(
+  result <- nanonext::recv(
     worker_state$socket,
     mode = "raw",
     block = FALSE
@@ -342,7 +341,7 @@ worker_run_walker <- function(walker, grid_state, pub_address,
 
   # Clean up worker socket
   tryCatch({
-    close(worker_state$socket)
+    nanonext::close(worker_state$socket)
   }, error = function(e) {
     logger::log_warn("Error closing worker socket: {e$message}")
   })

--- a/R/setup/fix_issue_30_nanonext_namespace.R
+++ b/R/setup/fix_issue_30_nanonext_namespace.R
@@ -1,0 +1,52 @@
+# Fix Issue #30: Add nanonext namespace prefixes in worker code
+# Date: 2025-11-19
+# Issue: https://github.com/JohnGavin/randomwalk/issues/30
+#
+# Problem: Worker code failed with "object is not a valid Socket or Context"
+# because nanonext functions were called without namespace prefix
+#
+# Solution: Add nanonext:: prefix to all nanonext function calls in R/async_worker.R
+
+library(gert)
+library(usethis)
+library(devtools)
+
+# 1. Created GitHub issue #30
+# gh('POST /repos/JohnGavin/randomwalk/issues',
+#    title = 'Fix missing nanonext namespace prefixes in worker code', ...)
+
+# 2. Switched to async-v2-phase1 (where async code exists)
+# gert::git_branch_checkout('async-v2-phase1')
+
+# 3. Created development branch from async-v2-phase1
+# gert::git_branch_create('fix-issue-30-nanonext-namespace', checkout = TRUE)
+
+# 4. Applied 4 fixes to R/async_worker.R:
+#    Line 41:  nano()      -> nanonext::nano()
+#    Line 44:  subscribe() -> nanonext::subscribe()
+#    Line 96:  recv()      -> nanonext::recv()
+#    Line 344: close()     -> nanonext::close()
+
+# 5. Run checks
+devtools::document()
+devtools::test()
+devtools::check()
+
+# 6. Stage and commit
+gert::git_add("R/async_worker.R")
+gert::git_add("R/setup/fix_issue_30_nanonext_namespace.R")
+gert::git_commit("Fix: Add nanonext namespace prefixes in worker code (#30)
+
+- Add nanonext:: prefix to nano(), subscribe(), recv(), close()
+- Fixes 'object is not a valid Socket or Context' error
+- Workers can now properly create and use subscriber sockets
+- Matches publisher code pattern in async_controller.R
+
+Closes #30")
+
+# 7. Push to remote (will trigger GitHub Actions)
+# gert::git_push()
+
+# 8. After checks pass, merge via PR
+# usethis::pr_merge_main()
+# usethis::pr_finish()


### PR DESCRIPTION
## Problem

Async crew integration was failing with errors about invalid Socket/Context.

## Root Cause

Worker code in R/async_worker.R called nanonext functions without namespace prefix at lines 41, 44, 96, 344.

## Solution

Added nanonext:: prefix to all 4 function calls: nano(), subscribe(), recv(), close().

## Changes
- R/async_worker.R: Fixed 4 namespace prefix issues
- R/setup/fix_issue_30_nanonext_namespace.R: Added reproducibility log

## Testing
- GitHub Actions will verify R CMD check passes
- Manual testing with run_simulation(workers = 2) should now work

Closes #30