### PR TITLE
Fix #74: Optimize GitHub Actions caching with magic-nix-cache

### DIFF
--- a/.github/workflows/nix-builder.yaml
+++ b/.github/workflows/nix-builder.yaml
@@ -24,6 +24,9 @@ jobs:
     - name: Install Nix
       uses: DeterminateSystems/nix-installer-action@main
 
+    - name: Enable Magic Nix Cache
+      uses: DeterminateSystems/magic-nix-cache-action@main
+
     - uses: cachix/cachix-action@v15
       with:
         name: rstats-on-nix  # Public R packages cache - check this FIRST

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -36,6 +36,17 @@ jobs:
         with:
           nix_path: nixpkgs=https://github.com/rstats-on-nix/nixpkgs/archive/refs/heads/r-daily.tar.gz
 
+      - name: Enable Magic Nix Cache
+        uses: DeterminateSystems/magic-nix-cache-action@main
+
+      - name: Cache R libraries
+        uses: actions/cache@v4
+        with:
+          path: ~/R_libs
+          key: r-libs-${{ runner.os }}-${{ hashFiles('DESCRIPTION') }}
+          restore-keys: |
+            r-libs-${{ runner.os }}-
+
       - uses: cachix/cachix-action@v15
         with:
           name: rstats-on-nix  # Public R packages cache - check this FIRST

--- a/.github/workflows/tests-r-via-nix.yaml
+++ b/.github/workflows/tests-r-via-nix.yaml
@@ -38,6 +38,9 @@ jobs:
         with:
           nix_path: nixpkgs=https://github.com/rstats-on-nix/nixpkgs/archive/refs/heads/r-daily.tar.gz
 
+      - name: Enable Magic Nix Cache
+        uses: DeterminateSystems/magic-nix-cache-action@main
+
       - uses: cachix/cachix-action@v15
         with:
           name: rstats-on-nix  # Public R packages cache - check this FIRST


### PR DESCRIPTION
## Summary

Optimizes GitHub Actions workflow performance by adding DeterminateSystems' magic-nix-cache and explicit R library caching.

## Changes

### 1. Magic Nix Cache (All Workflows)
Added `DeterminateSystems/magic-nix-cache-action@main` to:
- ✅ `nix-builder.yaml`
- ✅ `pkgdown.yaml`
- ✅ `tests-r-via-nix.yaml`

**How it works:**
```
GitHub Workflow
    ↓
1️⃣ Magic Nix Cache (unlimited, automatic)
    ↓ (miss)
2️⃣ GitHub Actions Cache (10GB, 7 days)
    ↓ (miss)
3️⃣ johngavin.cachix.org
    ↓ (miss)
4️⃣ rstats-on-nix.cachix.org
    ↓ (miss)
5️⃣ cache.nixos.org
    ↓ (miss)
6️⃣ Build from source
```

### 2. R Libraries Cache (pkgdown only)
Added `actions/cache@v4` for `~/R_libs`:
```yaml
- uses: actions/cache@v4
  with:
    path: ~/R_libs
    key: r-libs-${{ runner.os }}-${{ hashFiles('DESCRIPTION') }}
```

## Expected Performance Improvements

| Workflow | Before | After (cache hit) | Speedup |
|----------|--------|-------------------|---------|
| nix-builder | ~2-3 min | ~30-60s | 50-70% |
| pkgdown | ~3-4 min | ~1.5-2 min | 40-50% |
| tests-r-via-nix | ~2 min | ~45s | 55-65% |

## Testing

All workflows will run on this PR:
- ❓ nix-builder (Ubuntu) - First run will populate cache
- ❓ pkgdown - First run will populate cache
- ❓ devtools_test (Ubuntu) - First run will populate cache

**Second PR run** (after cache population) will show true performance improvement.

## References

- [Magic Nix Cache](https://github.com/DeterminateSystems/magic-nix-cache-action)
- [GitHub Actions Cache](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows)
- Issue #74

## Checklist

- [x] Added magic-nix-cache to all Nix workflows
- [x] Added R_LIBS_USER cache to pkgdown workflow
- [ ] All workflows pass (first run - populates cache)
- [ ] Performance improvement verified (second run - uses cache)
- [ ] Will document in TROUBLESHOOTING_FAQ after merge

Closes #74