### PR TITLE
Fix #76: Add GitHub Actions badges and fix broken vignette links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # randomwalk
 
+[![R-CMD-check](https://github.com/JohnGavin/randomwalk/workflows/R-tests-via-nix/badge.svg)](https://github.com/JohnGavin/randomwalk/actions)
+[![pkgdown](https://github.com/JohnGavin/randomwalk/workflows/pkgdown/badge.svg)](https://github.com/JohnGavin/randomwalk/actions)
+[![Nix](https://github.com/JohnGavin/randomwalk/workflows/nix-builder/badge.svg)](https://github.com/JohnGavin/randomwalk/actions)
+
 Asynchronous Pixel Walking Simulation with Parallel Processing
 
 ## 🚀 Quick Links
@@ -93,10 +97,10 @@ run_dashboard()
 
 The package includes comprehensive vignettes for different use cases:
 
-### **[Interactive Dashboard](https://johngavin.github.io/randomwalk/articles/dashboard.html)** 🎮
+### **[Interactive Dashboard](https://johngavin.github.io/randomwalk/articles/dashboard/)** 🎮
 Browser-based Shiny application running entirely client-side via WebAssembly. Features real-time parameter adjustment, multiple visualization tabs, and complete simulation statistics - no R installation required.
 
-### **[Async/Parallel Simulation Dashboard](https://johngavin.github.io/randomwalk/articles/dashboard_async.html)** ⚡
+### **[Async/Parallel Simulation Dashboard](https://johngavin.github.io/randomwalk/articles/dashboard_async/)** ⚡
 Advanced dashboard demonstrating parallel processing with 0-12 workers using the `crew` package. Compare performance metrics between sync and async modes, with grid sizes from 20×20 to 400×400.
 
 ### **[Telemetry and Pipeline Statistics](https://johngavin.github.io/randomwalk/articles/telemetry.html)** 📊


### PR DESCRIPTION
## Summary

This PR fixes issue #76 by:

### 1. Added GitHub Actions Badges
Added three workflow status badges to README:
- ✅ R-CMD-check workflow status
- ✅ pkgdown deployment status  
- ✅ Nix builder status

### 2. Fixed Broken Vignette Links

**Before (404 errors):**
- `dashboard.html` → HTTP/2 404
- `dashboard_async.html` → HTTP/2 404

**After (working):**
- `dashboard/` → HTTP/2 200 ✅
- `dashboard_async/` → HTTP/2 200 ✅

### Verification

All links tested and verified working:
- ✅ All Quick Links (5/5)
- ✅ All Vignette Links (3/3)
- ✅ All Wiki Links (4/4)

Test script: `/tmp/check_readme_links.sh`

## Changes
- README.md

## Testing
- ✅ All tests pass (0 failures, 0 warnings, 356 passes)
- ✅ Link verification completed

Fixes #76