### PR TITLE
Fix #67: Enable article building in pkgdown workflow

### DIFF
--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -69,9 +69,10 @@ jobs:
               pkgdown::clean_site(force = TRUE)
             }
 
-            # Build pkgdown site (skip article building for now)
+            # Build pkgdown site
             pkgdown::build_reference()
             pkgdown::build_home()
+            pkgdown::build_articles()  # Build all vignettes including dashboard_async
             pkgdown::build_articles_index()
           '"
 


### PR DESCRIPTION
## Problem

Article links return 404 errors:
- https://johngavin.github.io/randomwalk/articles/dashboard.html
- https://johngavin.github.io/randomwalk/articles/dashboard_async.html

## Root Cause

The pkgdown workflow only builds the articles INDEX, not the actual HTML files.

## Solution

Changed `.github/workflows/pkgdown.yaml` to call `pkgdown::build_articles()` which renders all .qmd vignettes to HTML.

## Testing

After this PR merges and GitHub Actions completes:
- ✅ https://johngavin.github.io/randomwalk/articles/dashboard.html should work
- ✅ https://johngavin.github.io/randomwalk/articles/dashboard_async.html should work

Closes #67