### PR TITLE
Fix #94: Pre-build missing vignette HTML files

### DIFF
--- a/R/setup/fix_issue_94_broken_vignette_links.R
+++ b/R/setup/fix_issue_94_broken_vignette_links.R
@@ -1,0 +1,73 @@
+# Fix Issue #94: Broken vignette links on website - Missing pre-built HTML
+# Created: 2025-12-05
+# Purpose: Pre-build missing vignette HTML files so pkgdown can include them
+#
+# Problem: Three vignette links were broken on the website because the HTML
+# files didn't exist in vignettes/ directory:
+# - https://johngavin.github.io/randomwalk/articles/dashboard.html (existed)
+# - https://johngavin.github.io/randomwalk/articles/dashboard_async.html (MISSING)
+# - https://johngavin.github.io/randomwalk/articles/dynamic_broadcasting.html (MISSING)
+#
+# Solution: Pre-built the missing HTML files using Quarto
+
+library(gert)
+library(usethis)
+
+# Step 1: Created issue #94 on GitHub
+# https://github.com/JohnGavin/randomwalk/issues/94
+
+# Step 2: Create dev branch
+# Already done: fix-issue-94-broken-vignette-links
+
+# Step 3: Build missing vignettes
+
+# Build dashboard_async.html
+# Command: cd vignettes && quarto render dashboard_async.qmd
+# Output: vignettes/dashboard_async.html (29K)
+
+# Build dynamic_broadcasting.html
+# First removed library(randomwalk) from setup chunk (vignette is documentation only)
+# Command: quarto render dynamic_broadcasting.qmd
+# Output: vignettes/dynamic_broadcasting.html (78K)
+
+# Step 4: Verify all vignettes exist
+# ✅ vignettes/dashboard.html (50K)
+# ✅ vignettes/dashboard_async.html (29K)
+# ✅ vignettes/dynamic_broadcasting.html (78K)
+# ✅ vignettes/telemetry.html (103K)
+
+# Step 5: Commit changes
+gert::git_add("vignettes/dashboard_async.html")
+gert::git_add("vignettes/dynamic_broadcasting.html")
+gert::git_add("vignettes/dynamic_broadcasting.qmd")  # Modified to remove library() call
+gert::git_add("R/setup/fix_issue_94_broken_vignette_links.R")
+
+gert::git_commit("Fix #94: Pre-build missing vignette HTML files
+
+Problem: Three vignette links were broken on the website:
+- dashboard_async.html (missing)
+- dynamic_broadcasting.html (missing)
+
+Root cause: pkgdown requires pre-built HTML files in vignettes/ directory
+to include them on the website.
+
+Solution: Pre-built both missing vignettes using Quarto:
+- dashboard_async.html (29K)
+- dynamic_broadcasting.html (78K)
+
+Also modified dynamic_broadcasting.qmd to remove library(randomwalk)
+call in setup chunk since the vignette is documentation only (no code
+execution needed).
+
+All vignette links will now work on the website.
+
+Related: Issue #94 (High priority - broken links)")
+
+cat("✓ Changes committed\n")
+
+# Step 6: DO NOT push to GitHub yet (user requested to wait)
+# usethis::pr_push()  # Will run when user approves
+
+# Step 7: Wait for GitHub Actions
+# Step 8: Merge PR
+# Step 9: Log everything (this file)

--- a/vignettes/dashboard_async.html
+++ b/vignettes/dashboard_async.html
@@ -1,0 +1,637 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en"><head>
+
+<meta charset="utf-8">
+<meta name="generator" content="quarto-1.7.34">
+
+<meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
+
+
+<title>Async/Parallel Simulation Dashboard</title>
+<style>
+code{white-space: pre-wrap;}
+span.smallcaps{font-variant: small-caps;}
+div.columns{display: flex; gap: min(4vw, 1.5em);}
+div.column{flex: auto; overflow-x: auto;}
+div.hanging-indent{margin-left: 1.5em; text-indent: -1.5em;}
+ul.task-list{list-style: none;}
+ul.task-list li input[type="checkbox"] {
+  width: 0.8em;
+  margin: 0 0.8em 0.2em -1em; /* quarto-specific, see https://github.com/quarto-dev/quarto-cli/issues/4556 */ 
+  vertical-align: middle;
+}
+</style>
+
+
+<script src="dashboard_async_files/libs/clipboard/clipboard.min.js"></script>
+<script src="dashboard_async_files/libs/quarto-html/quarto.js" type="module"></script>
+<script src="dashboard_async_files/libs/quarto-html/tabsets/tabsets.js" type="module"></script>
+<script src="dashboard_async_files/libs/quarto-html/popper.min.js"></script>
+<script src="dashboard_async_files/libs/quarto-html/tippy.umd.min.js"></script>
+<script src="dashboard_async_files/libs/quarto-html/anchor.min.js"></script>
+<link href="dashboard_async_files/libs/quarto-html/tippy.css" rel="stylesheet">
+<link href="dashboard_async_files/libs/quarto-html/quarto-syntax-highlighting-c8ad9e5dbd60b7b70b38521ab19b7da4.css" rel="stylesheet" id="quarto-text-highlighting-styles">
+<script src="dashboard_async_files/libs/bootstrap/bootstrap.min.js"></script>
+<link href="dashboard_async_files/libs/bootstrap/bootstrap-icons.css" rel="stylesheet">
+<link href="dashboard_async_files/libs/bootstrap/bootstrap-b232414f0569882df4359abfb7cfba3f.min.css" rel="stylesheet" append-hash="true" id="quarto-bootstrap" data-mode="light">
+
+
+</head>
+
+<body class="quarto-light">
+
+<div id="quarto-content" class="page-columns page-rows-contents page-layout-article">
+<div id="quarto-margin-sidebar" class="sidebar margin-sidebar">
+  <nav id="TOC" role="doc-toc" class="toc-active">
+    <h2 id="toc-title">Table of contents</h2>
+   
+  <ul>
+  <li><a href="#async-random-walk-simulation-dashboard" id="toc-async-random-walk-simulation-dashboard" class="nav-link active" data-scroll-target="#async-random-walk-simulation-dashboard">Async Random Walk Simulation Dashboard</a>
+  <ul class="collapse">
+  <li><a href="#launch-the-interactive-dashboard" id="toc-launch-the-interactive-dashboard" class="nav-link" data-scroll-target="#launch-the-interactive-dashboard">🚀 Launch the Interactive Dashboard</a></li>
+  <li><a href="#overview" id="toc-overview" class="nav-link" data-scroll-target="#overview">Overview</a>
+  <ul class="collapse">
+  <li><a href="#key-features" id="toc-key-features" class="nav-link" data-scroll-target="#key-features">Key Features</a></li>
+  <li><a href="#async-vs-sync-mode" id="toc-async-vs-sync-mode" class="nav-link" data-scroll-target="#async-vs-sync-mode">Async vs Sync Mode</a></li>
+  </ul></li>
+  <li><a href="#architecture" id="toc-architecture" class="nav-link" data-scroll-target="#architecture">Architecture</a>
+  <ul class="collapse">
+  <li><a href="#async-parameters" id="toc-async-parameters" class="nav-link" data-scroll-target="#async-parameters">Async Parameters</a></li>
+  <li><a href="#async-execution-model" id="toc-async-execution-model" class="nav-link" data-scroll-target="#async-execution-model">Async Execution Model</a></li>
+  <li><a href="#performance-metrics" id="toc-performance-metrics" class="nav-link" data-scroll-target="#performance-metrics">Performance Metrics</a></li>
+  </ul></li>
+  <li><a href="#usage-examples" id="toc-usage-examples" class="nav-link" data-scroll-target="#usage-examples">Usage Examples</a>
+  <ul class="collapse">
+  <li><a href="#testing-async-performance" id="toc-testing-async-performance" class="nav-link" data-scroll-target="#testing-async-performance">Testing Async Performance</a></li>
+  <li><a href="#optimal-worker-count" id="toc-optimal-worker-count" class="nav-link" data-scroll-target="#optimal-worker-count">Optimal Worker Count</a></li>
+  <li><a href="#expected-results" id="toc-expected-results" class="nav-link" data-scroll-target="#expected-results">Expected Results</a></li>
+  </ul></li>
+  <li><a href="#technical-details" id="toc-technical-details" class="nav-link" data-scroll-target="#technical-details">Technical Details</a>
+  <ul class="collapse">
+  <li><a href="#static-snapshot-architecture" id="toc-static-snapshot-architecture" class="nav-link" data-scroll-target="#static-snapshot-architecture">Static Snapshot Architecture</a></li>
+  <li><a href="#why-results-differ" id="toc-why-results-differ" class="nav-link" data-scroll-target="#why-results-differ">Why Results Differ</a></li>
+  </ul></li>
+  <li><a href="#see-also" id="toc-see-also" class="nav-link" data-scroll-target="#see-also">See Also</a></li>
+  <li><a href="#summary" id="toc-summary" class="nav-link" data-scroll-target="#summary">Summary</a></li>
+  </ul></li>
+  </ul>
+</nav>
+</div>
+<main class="content" id="quarto-document-content">
+
+<header id="title-block-header" class="quarto-title-block default">
+<div class="quarto-title">
+<h1 class="title">Async/Parallel Simulation Dashboard</h1>
+</div>
+
+
+
+<div class="quarto-title-meta">
+
+    
+  
+    
+  </div>
+  
+
+
+</header>
+
+
+<section id="async-random-walk-simulation-dashboard" class="level1">
+<h1>Async Random Walk Simulation Dashboard</h1>
+<p>This vignette provides documentation for the <strong>fully interactive async/parallel Shiny application</strong> that runs directly in your browser using WebAssembly. Test parallel execution with multiple workers!</p>
+<section id="launch-the-interactive-dashboard" class="level2">
+<h2 class="anchored" data-anchor-id="launch-the-interactive-dashboard">🚀 Launch the Interactive Dashboard</h2>
+<p><strong><a href="../dashboard_async/" class="btn btn-primary btn-lg">Click here to open the Async Dashboard</a></strong></p>
+<p>The dashboard runs entirely in your browser - no R installation or server required!</p>
+</section>
+<section id="overview" class="level2">
+<h2 class="anchored" data-anchor-id="overview">Overview</h2>
+<p>The async dashboard demonstrates the <strong>parallel processing capabilities</strong> of the <code>randomwalk</code> package using the <code>crew</code> package for worker management. The simulation runs entirely client-side using WebAssembly technology.</p>
+<section id="key-features" class="level3">
+<h3 class="anchored" data-anchor-id="key-features">Key Features</h3>
+<ul>
+<li><strong>Parallel Execution</strong>: Choose 0-12 workers for sync or async mode</li>
+<li><strong>Performance Metrics</strong>: Compare execution time with different worker counts</li>
+<li><strong>Real-time Visualization</strong>: View grid state, walker paths, and statistics</li>
+<li><strong>No Server Required</strong>: Runs entirely in your browser via WebAssembly</li>
+<li><strong>Package Integration</strong>: Uses the actual <code>randomwalk</code> package async functions</li>
+<li><strong>Flexible Parameters</strong>: Grid sizes from 20x20 to 400x400, dynamic walker constraints</li>
+</ul>
+</section>
+<section id="async-vs-sync-mode" class="level3">
+<h3 class="anchored" data-anchor-id="async-vs-sync-mode">Async vs Sync Mode</h3>
+<ul>
+<li><strong>Sync Mode</strong> (<code>workers = 0</code>): Sequential processing, predictable results</li>
+<li><strong>Async Mode</strong> (<code>workers &gt; 0</code>): Parallel processing using <code>crew</code> workers
+<ul>
+<li>Workers process walkers independently</li>
+<li>Potential speedup with multiple CPU cores</li>
+<li>Results may differ slightly (workers use static grid snapshots)</li>
+</ul></li>
+</ul>
+</section>
+</section>
+<section id="architecture" class="level2">
+<h2 class="anchored" data-anchor-id="architecture">Architecture</h2>
+<p>The async dashboard extends the sync dashboard with parallel processing capabilities:</p>
+<section id="async-parameters" class="level3">
+<h3 class="anchored" data-anchor-id="async-parameters">Async Parameters</h3>
+<p><strong>Number of Workers</strong>: 0-12 workers - 0 workers = Sync mode (baseline for comparison) - 1+ workers = Async mode (parallel execution) - More workers may improve performance (up to CPU core limit)</p>
+<p><strong>Grid Size</strong>: 20-400 (in steps of 20) - Smaller grids (20-100): Fast simulations for quick testing - Medium grids (100-200): Balanced performance and coverage - Large grids (200-400): Stress testing and performance evaluation</p>
+<p><strong>Number of Walkers</strong>: Dynamically constrained to 70% of grid pixels - Automatically adjusts maximum based on selected grid size - Prevents overcrowding and ensures simulation quality</p>
+</section>
+<section id="async-execution-model" class="level3">
+<h3 class="anchored" data-anchor-id="async-execution-model">Async Execution Model</h3>
+<ol type="1">
+<li><strong>Worker Initialization</strong>: <code>crew</code> spawns requested number of R worker processes</li>
+<li><strong>Task Distribution</strong>: Walkers distributed across workers</li>
+<li><strong>Independent Processing</strong>: Each worker processes assigned walkers using static grid snapshot</li>
+<li><strong>Result Collection</strong>: Main process collects completed walker results</li>
+<li><strong>Resource Cleanup</strong>: Workers terminated after simulation completes</li>
+</ol>
+</section>
+<section id="performance-metrics" class="level3">
+<h3 class="anchored" data-anchor-id="performance-metrics">Performance Metrics</h3>
+<p>The Performance tab shows: - Execution mode (sync vs async) - Number of workers used - Elapsed time - Steps per second throughput - Performance analysis and speedup estimation</p>
+</section>
+</section>
+<section id="usage-examples" class="level2">
+<h2 class="anchored" data-anchor-id="usage-examples">Usage Examples</h2>
+<section id="testing-async-performance" class="level3">
+<h3 class="anchored" data-anchor-id="testing-async-performance">Testing Async Performance</h3>
+<ol type="1">
+<li><strong>Baseline</strong>: Run with <code>workers = 0</code> (sync mode)</li>
+<li><strong>Note timing</strong>: Check elapsed time in Performance tab</li>
+<li><strong>Scale up</strong>: Increase workers to 2, 4, 8, or 12</li>
+<li><strong>Compare</strong>: Observe speedup in Performance tab</li>
+<li><strong>Test large grids</strong>: Try 200x200 or 400x400 with 8-12 workers</li>
+</ol>
+</section>
+<section id="optimal-worker-count" class="level3">
+<h3 class="anchored" data-anchor-id="optimal-worker-count">Optimal Worker Count</h3>
+<ul>
+<li><strong>Small simulations</strong> (20-100 grid): 1-2 workers (overhead dominates)</li>
+<li><strong>Medium simulations</strong> (100-200 grid): 2-4 workers (good speedup)</li>
+<li><strong>Large simulations</strong> (200-400 grid): 4-12 workers (max speedup)</li>
+<li><strong>Rule of thumb</strong>: Don’t exceed number of CPU cores</li>
+</ul>
+</section>
+<section id="expected-results" class="level3">
+<h3 class="anchored" data-anchor-id="expected-results">Expected Results</h3>
+<ul>
+<li><strong>Sync vs Async</strong>: Results may differ (static snapshots)</li>
+<li><strong>Speedup</strong>: Typically 1.5-2x with 2 workers, up to 3-4x with 8-12 workers</li>
+<li><strong>Variability</strong>: Speedup depends on walker termination patterns and grid size</li>
+<li><strong>Overhead</strong>: Some overhead from worker management</li>
+<li><strong>Large grids</strong>: Better parallelization efficiency with more workers</li>
+</ul>
+</section>
+</section>
+<section id="technical-details" class="level2">
+<h2 class="anchored" data-anchor-id="technical-details">Technical Details</h2>
+<section id="static-snapshot-architecture" class="level3">
+<h3 class="anchored" data-anchor-id="static-snapshot-architecture">Static Snapshot Architecture</h3>
+<p>Workers operate on frozen grid state:</p>
+<p><strong>Pros:</strong> - ✅ No serialization issues - ✅ Simple, reliable implementation - ✅ Fast worker execution</p>
+<p><strong>Cons:</strong> - ⚠️ Workers don’t see real-time updates - ⚠️ Results may differ from sync mode - ⚠️ Some walker interactions missed</p>
+</section>
+<section id="why-results-differ" class="level3">
+<h3 class="anchored" data-anchor-id="why-results-differ">Why Results Differ</h3>
+<p><strong>Sync mode example:</strong> 1. Walker A terminates at (5,5) → pixel becomes black 2. Walker B sees black pixel at (5,5) 3. Walker B terminates early when near (5,5) 4. Result: 2 black pixels</p>
+<p><strong>Async mode example:</strong> 1. Worker 1: Walker A terminates at (5,5) 2. Worker 2: Walker B doesn’t see (5,5) is black 3. Walker B continues until termination at (7,8) 4. Result: 3 black pixels</p>
+<p>This is <strong>expected behavior</strong> and doesn’t indicate a bug.</p>
+</section>
+</section>
+<section id="see-also" class="level2">
+<h2 class="anchored" data-anchor-id="see-also">See Also</h2>
+<ul>
+<li><a href="../dashboard/">Sync Dashboard</a> - Sync-only dashboard</li>
+<li><code>vignette("telemetry")</code> - Pipeline statistics</li>
+<li><code>?run_simulation</code> - Core simulation function (<code>workers</code> parameter)</li>
+<li><a href="https://wlandau.github.io/crew/">crew Package</a> - Distributed worker launcher</li>
+</ul>
+</section>
+<section id="summary" class="level2">
+<h2 class="anchored" data-anchor-id="summary">Summary</h2>
+<p>This async dashboard provides:</p>
+<ul>
+<li><strong>Parallel Execution</strong>: Test async performance with multiple workers</li>
+<li><strong>Performance Metrics</strong>: Compare sync vs async timing</li>
+<li><strong>Interactive Testing</strong>: Adjust worker count in real-time</li>
+<li><strong>Educational</strong>: Understand async/parallel random walks</li>
+<li><strong>Production-Ready</strong>: Uses the actual async implementation from <code>randomwalk</code> package</li>
+</ul>
+<p>The async implementation uses static grid snapshots for simplicity and reliability, trading real-time synchronization for predictable, robust parallel execution.</p>
+<p><strong><a href="../dashboard_async/" class="btn btn-primary">Launch the Async Dashboard →</a></strong></p>
+</section>
+</section>
+
+</main>
+<!-- /main column -->
+<script id="quarto-html-after-body" type="application/javascript">
+  window.document.addEventListener("DOMContentLoaded", function (event) {
+    const icon = "";
+    const anchorJS = new window.AnchorJS();
+    anchorJS.options = {
+      placement: 'right',
+      icon: icon
+    };
+    anchorJS.add('.anchored');
+    const isCodeAnnotation = (el) => {
+      for (const clz of el.classList) {
+        if (clz.startsWith('code-annotation-')) {                     
+          return true;
+        }
+      }
+      return false;
+    }
+    const onCopySuccess = function(e) {
+      // button target
+      const button = e.trigger;
+      // don't keep focus
+      button.blur();
+      // flash "checked"
+      button.classList.add('code-copy-button-checked');
+      var currentTitle = button.getAttribute("title");
+      button.setAttribute("title", "Copied!");
+      let tooltip;
+      if (window.bootstrap) {
+        button.setAttribute("data-bs-toggle", "tooltip");
+        button.setAttribute("data-bs-placement", "left");
+        button.setAttribute("data-bs-title", "Copied!");
+        tooltip = new bootstrap.Tooltip(button, 
+          { trigger: "manual", 
+            customClass: "code-copy-button-tooltip",
+            offset: [0, -8]});
+        tooltip.show();    
+      }
+      setTimeout(function() {
+        if (tooltip) {
+          tooltip.hide();
+          button.removeAttribute("data-bs-title");
+          button.removeAttribute("data-bs-toggle");
+          button.removeAttribute("data-bs-placement");
+        }
+        button.setAttribute("title", currentTitle);
+        button.classList.remove('code-copy-button-checked');
+      }, 1000);
+      // clear code selection
+      e.clearSelection();
+    }
+    const getTextToCopy = function(trigger) {
+        const codeEl = trigger.previousElementSibling.cloneNode(true);
+        for (const childEl of codeEl.children) {
+          if (isCodeAnnotation(childEl)) {
+            childEl.remove();
+          }
+        }
+        return codeEl.innerText;
+    }
+    const clipboard = new window.ClipboardJS('.code-copy-button:not([data-in-quarto-modal])', {
+      text: getTextToCopy
+    });
+    clipboard.on('success', onCopySuccess);
+    if (window.document.getElementById('quarto-embedded-source-code-modal')) {
+      const clipboardModal = new window.ClipboardJS('.code-copy-button[data-in-quarto-modal]', {
+        text: getTextToCopy,
+        container: window.document.getElementById('quarto-embedded-source-code-modal')
+      });
+      clipboardModal.on('success', onCopySuccess);
+    }
+      var localhostRegex = new RegExp(/^(?:http|https):\/\/localhost\:?[0-9]*\//);
+      var mailtoRegex = new RegExp(/^mailto:/);
+        var filterRegex = new RegExp('/' + window.location.host + '/');
+      var isInternal = (href) => {
+          return filterRegex.test(href) || localhostRegex.test(href) || mailtoRegex.test(href);
+      }
+      // Inspect non-navigation links and adorn them if external
+     var links = window.document.querySelectorAll('a[href]:not(.nav-link):not(.navbar-brand):not(.toc-action):not(.sidebar-link):not(.sidebar-item-toggle):not(.pagination-link):not(.no-external):not([aria-hidden]):not(.dropdown-item):not(.quarto-navigation-tool):not(.about-link)');
+      for (var i=0; i<links.length; i++) {
+        const link = links[i];
+        if (!isInternal(link.href)) {
+          // undo the damage that might have been done by quarto-nav.js in the case of
+          // links that we want to consider external
+          if (link.dataset.originalHref !== undefined) {
+            link.href = link.dataset.originalHref;
+          }
+        }
+      }
+    function tippyHover(el, contentFn, onTriggerFn, onUntriggerFn) {
+      const config = {
+        allowHTML: true,
+        maxWidth: 500,
+        delay: 100,
+        arrow: false,
+        appendTo: function(el) {
+            return el.parentElement;
+        },
+        interactive: true,
+        interactiveBorder: 10,
+        theme: 'quarto',
+        placement: 'bottom-start',
+      };
+      if (contentFn) {
+        config.content = contentFn;
+      }
+      if (onTriggerFn) {
+        config.onTrigger = onTriggerFn;
+      }
+      if (onUntriggerFn) {
+        config.onUntrigger = onUntriggerFn;
+      }
+      window.tippy(el, config); 
+    }
+    const noterefs = window.document.querySelectorAll('a[role="doc-noteref"]');
+    for (var i=0; i<noterefs.length; i++) {
+      const ref = noterefs[i];
+      tippyHover(ref, function() {
+        // use id or data attribute instead here
+        let href = ref.getAttribute('data-footnote-href') || ref.getAttribute('href');
+        try { href = new URL(href).hash; } catch {}
+        const id = href.replace(/^#\/?/, "");
+        const note = window.document.getElementById(id);
+        if (note) {
+          return note.innerHTML;
+        } else {
+          return "";
+        }
+      });
+    }
+    const xrefs = window.document.querySelectorAll('a.quarto-xref');
+    const processXRef = (id, note) => {
+      // Strip column container classes
+      const stripColumnClz = (el) => {
+        el.classList.remove("page-full", "page-columns");
+        if (el.children) {
+          for (const child of el.children) {
+            stripColumnClz(child);
+          }
+        }
+      }
+      stripColumnClz(note)
+      if (id === null || id.startsWith('sec-')) {
+        // Special case sections, only their first couple elements
+        const container = document.createElement("div");
+        if (note.children && note.children.length > 2) {
+          container.appendChild(note.children[0].cloneNode(true));
+          for (let i = 1; i < note.children.length; i++) {
+            const child = note.children[i];
+            if (child.tagName === "P" && child.innerText === "") {
+              continue;
+            } else {
+              container.appendChild(child.cloneNode(true));
+              break;
+            }
+          }
+          if (window.Quarto?.typesetMath) {
+            window.Quarto.typesetMath(container);
+          }
+          return container.innerHTML
+        } else {
+          if (window.Quarto?.typesetMath) {
+            window.Quarto.typesetMath(note);
+          }
+          return note.innerHTML;
+        }
+      } else {
+        // Remove any anchor links if they are present
+        const anchorLink = note.querySelector('a.anchorjs-link');
+        if (anchorLink) {
+          anchorLink.remove();
+        }
+        if (window.Quarto?.typesetMath) {
+          window.Quarto.typesetMath(note);
+        }
+        if (note.classList.contains("callout")) {
+          return note.outerHTML;
+        } else {
+          return note.innerHTML;
+        }
+      }
+    }
+    for (var i=0; i<xrefs.length; i++) {
+      const xref = xrefs[i];
+      tippyHover(xref, undefined, function(instance) {
+        instance.disable();
+        let url = xref.getAttribute('href');
+        let hash = undefined; 
+        if (url.startsWith('#')) {
+          hash = url;
+        } else {
+          try { hash = new URL(url).hash; } catch {}
+        }
+        if (hash) {
+          const id = hash.replace(/^#\/?/, "");
+          const note = window.document.getElementById(id);
+          if (note !== null) {
+            try {
+              const html = processXRef(id, note.cloneNode(true));
+              instance.setContent(html);
+            } finally {
+              instance.enable();
+              instance.show();
+            }
+          } else {
+            // See if we can fetch this
+            fetch(url.split('#')[0])
+            .then(res => res.text())
+            .then(html => {
+              const parser = new DOMParser();
+              const htmlDoc = parser.parseFromString(html, "text/html");
+              const note = htmlDoc.getElementById(id);
+              if (note !== null) {
+                const html = processXRef(id, note);
+                instance.setContent(html);
+              } 
+            }).finally(() => {
+              instance.enable();
+              instance.show();
+            });
+          }
+        } else {
+          // See if we can fetch a full url (with no hash to target)
+          // This is a special case and we should probably do some content thinning / targeting
+          fetch(url)
+          .then(res => res.text())
+          .then(html => {
+            const parser = new DOMParser();
+            const htmlDoc = parser.parseFromString(html, "text/html");
+            const note = htmlDoc.querySelector('main.content');
+            if (note !== null) {
+              // This should only happen for chapter cross references
+              // (since there is no id in the URL)
+              // remove the first header
+              if (note.children.length > 0 && note.children[0].tagName === "HEADER") {
+                note.children[0].remove();
+              }
+              const html = processXRef(null, note);
+              instance.setContent(html);
+            } 
+          }).finally(() => {
+            instance.enable();
+            instance.show();
+          });
+        }
+      }, function(instance) {
+      });
+    }
+        let selectedAnnoteEl;
+        const selectorForAnnotation = ( cell, annotation) => {
+          let cellAttr = 'data-code-cell="' + cell + '"';
+          let lineAttr = 'data-code-annotation="' +  annotation + '"';
+          const selector = 'span[' + cellAttr + '][' + lineAttr + ']';
+          return selector;
+        }
+        const selectCodeLines = (annoteEl) => {
+          const doc = window.document;
+          const targetCell = annoteEl.getAttribute("data-target-cell");
+          const targetAnnotation = annoteEl.getAttribute("data-target-annotation");
+          const annoteSpan = window.document.querySelector(selectorForAnnotation(targetCell, targetAnnotation));
+          const lines = annoteSpan.getAttribute("data-code-lines").split(",");
+          const lineIds = lines.map((line) => {
+            return targetCell + "-" + line;
+          })
+          let top = null;
+          let height = null;
+          let parent = null;
+          if (lineIds.length > 0) {
+              //compute the position of the single el (top and bottom and make a div)
+              const el = window.document.getElementById(lineIds[0]);
+              top = el.offsetTop;
+              height = el.offsetHeight;
+              parent = el.parentElement.parentElement;
+            if (lineIds.length > 1) {
+              const lastEl = window.document.getElementById(lineIds[lineIds.length - 1]);
+              const bottom = lastEl.offsetTop + lastEl.offsetHeight;
+              height = bottom - top;
+            }
+            if (top !== null && height !== null && parent !== null) {
+              // cook up a div (if necessary) and position it 
+              let div = window.document.getElementById("code-annotation-line-highlight");
+              if (div === null) {
+                div = window.document.createElement("div");
+                div.setAttribute("id", "code-annotation-line-highlight");
+                div.style.position = 'absolute';
+                parent.appendChild(div);
+              }
+              div.style.top = top - 2 + "px";
+              div.style.height = height + 4 + "px";
+              div.style.left = 0;
+              let gutterDiv = window.document.getElementById("code-annotation-line-highlight-gutter");
+              if (gutterDiv === null) {
+                gutterDiv = window.document.createElement("div");
+                gutterDiv.setAttribute("id", "code-annotation-line-highlight-gutter");
+                gutterDiv.style.position = 'absolute';
+                const codeCell = window.document.getElementById(targetCell);
+                const gutter = codeCell.querySelector('.code-annotation-gutter');
+                gutter.appendChild(gutterDiv);
+              }
+              gutterDiv.style.top = top - 2 + "px";
+              gutterDiv.style.height = height + 4 + "px";
+            }
+            selectedAnnoteEl = annoteEl;
+          }
+        };
+        const unselectCodeLines = () => {
+          const elementsIds = ["code-annotation-line-highlight", "code-annotation-line-highlight-gutter"];
+          elementsIds.forEach((elId) => {
+            const div = window.document.getElementById(elId);
+            if (div) {
+              div.remove();
+            }
+          });
+          selectedAnnoteEl = undefined;
+        };
+          // Handle positioning of the toggle
+      window.addEventListener(
+        "resize",
+        throttle(() => {
+          elRect = undefined;
+          if (selectedAnnoteEl) {
+            selectCodeLines(selectedAnnoteEl);
+          }
+        }, 10)
+      );
+      function throttle(fn, ms) {
+      let throttle = false;
+      let timer;
+        return (...args) => {
+          if(!throttle) { // first call gets through
+              fn.apply(this, args);
+              throttle = true;
+          } else { // all the others get throttled
+              if(timer) clearTimeout(timer); // cancel #2
+              timer = setTimeout(() => {
+                fn.apply(this, args);
+                timer = throttle = false;
+              }, ms);
+          }
+        };
+      }
+        // Attach click handler to the DT
+        const annoteDls = window.document.querySelectorAll('dt[data-target-cell]');
+        for (const annoteDlNode of annoteDls) {
+          annoteDlNode.addEventListener('click', (event) => {
+            const clickedEl = event.target;
+            if (clickedEl !== selectedAnnoteEl) {
+              unselectCodeLines();
+              const activeEl = window.document.querySelector('dt[data-target-cell].code-annotation-active');
+              if (activeEl) {
+                activeEl.classList.remove('code-annotation-active');
+              }
+              selectCodeLines(clickedEl);
+              clickedEl.classList.add('code-annotation-active');
+            } else {
+              // Unselect the line
+              unselectCodeLines();
+              clickedEl.classList.remove('code-annotation-active');
+            }
+          });
+        }
+    const findCites = (el) => {
+      const parentEl = el.parentElement;
+      if (parentEl) {
+        const cites = parentEl.dataset.cites;
+        if (cites) {
+          return {
+            el,
+            cites: cites.split(' ')
+          };
+        } else {
+          return findCites(el.parentElement)
+        }
+      } else {
+        return undefined;
+      }
+    };
+    var bibliorefs = window.document.querySelectorAll('a[role="doc-biblioref"]');
+    for (var i=0; i<bibliorefs.length; i++) {
+      const ref = bibliorefs[i];
+      const citeInfo = findCites(ref);
+      if (citeInfo) {
+        tippyHover(citeInfo.el, function() {
+          var popup = window.document.createElement('div');
+          citeInfo.cites.forEach(function(cite) {
+            var citeDiv = window.document.createElement('div');
+            citeDiv.classList.add('hanging-indent');
+            citeDiv.classList.add('csl-entry');
+            var biblioDiv = window.document.getElementById('ref-' + cite);
+            if (biblioDiv) {
+              citeDiv.innerHTML = biblioDiv.innerHTML;
+            }
+            popup.appendChild(citeDiv);
+          });
+          return popup.innerHTML;
+        });
+      }
+    }
+  });
+  </script>
+</div> <!-- /content -->
+
+
+
+
+</body></html>

--- a/vignettes/dynamic_broadcasting.html
+++ b/vignettes/dynamic_broadcasting.html
@@ -1,0 +1,1157 @@
+<!DOCTYPE html>
+<html xmlns="http://www.w3.org/1999/xhtml" lang="en" xml:lang="en"><head>
+
+<meta charset="utf-8">
+<meta name="generator" content="quarto-1.7.34">
+
+<meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
+
+
+<title>Dynamic Grid Broadcasting</title>
+<style>
+code{white-space: pre-wrap;}
+span.smallcaps{font-variant: small-caps;}
+div.columns{display: flex; gap: min(4vw, 1.5em);}
+div.column{flex: auto; overflow-x: auto;}
+div.hanging-indent{margin-left: 1.5em; text-indent: -1.5em;}
+ul.task-list{list-style: none;}
+ul.task-list li input[type="checkbox"] {
+  width: 0.8em;
+  margin: 0 0.8em 0.2em -1em; /* quarto-specific, see https://github.com/quarto-dev/quarto-cli/issues/4556 */ 
+  vertical-align: middle;
+}
+/* CSS for syntax highlighting */
+html { -webkit-text-size-adjust: 100%; }
+pre > code.sourceCode { white-space: pre; position: relative; }
+pre > code.sourceCode > span { display: inline-block; line-height: 1.25; }
+pre > code.sourceCode > span:empty { height: 1.2em; }
+.sourceCode { overflow: visible; }
+code.sourceCode > span { color: inherit; text-decoration: inherit; }
+div.sourceCode { margin: 1em 0; }
+pre.sourceCode { margin: 0; }
+@media screen {
+div.sourceCode { overflow: auto; }
+}
+@media print {
+pre > code.sourceCode { white-space: pre-wrap; }
+pre > code.sourceCode > span { text-indent: -5em; padding-left: 5em; }
+}
+pre.numberSource code
+  { counter-reset: source-line 0; }
+pre.numberSource code > span
+  { position: relative; left: -4em; counter-increment: source-line; }
+pre.numberSource code > span > a:first-child::before
+  { content: counter(source-line);
+    position: relative; left: -1em; text-align: right; vertical-align: baseline;
+    border: none; display: inline-block;
+    -webkit-touch-callout: none; -webkit-user-select: none;
+    -khtml-user-select: none; -moz-user-select: none;
+    -ms-user-select: none; user-select: none;
+    padding: 0 4px; width: 4em;
+  }
+pre.numberSource { margin-left: 3em;  padding-left: 4px; }
+div.sourceCode
+  {   }
+@media screen {
+pre > code.sourceCode > span > a:first-child::before { text-decoration: underline; }
+}
+</style>
+
+
+<script src="dynamic_broadcasting_files/libs/clipboard/clipboard.min.js"></script>
+<script src="dynamic_broadcasting_files/libs/quarto-html/quarto.js" type="module"></script>
+<script src="dynamic_broadcasting_files/libs/quarto-html/tabsets/tabsets.js" type="module"></script>
+<script src="dynamic_broadcasting_files/libs/quarto-html/popper.min.js"></script>
+<script src="dynamic_broadcasting_files/libs/quarto-html/tippy.umd.min.js"></script>
+<script src="dynamic_broadcasting_files/libs/quarto-html/anchor.min.js"></script>
+<link href="dynamic_broadcasting_files/libs/quarto-html/tippy.css" rel="stylesheet">
+<link href="dynamic_broadcasting_files/libs/quarto-html/quarto-syntax-highlighting-c8ad9e5dbd60b7b70b38521ab19b7da4.css" rel="stylesheet" id="quarto-text-highlighting-styles">
+<script src="dynamic_broadcasting_files/libs/bootstrap/bootstrap.min.js"></script>
+<link href="dynamic_broadcasting_files/libs/bootstrap/bootstrap-icons.css" rel="stylesheet">
+<link href="dynamic_broadcasting_files/libs/bootstrap/bootstrap-b232414f0569882df4359abfb7cfba3f.min.css" rel="stylesheet" append-hash="true" id="quarto-bootstrap" data-mode="light">
+
+
+</head>
+
+<body class="quarto-light">
+
+<div id="quarto-content" class="page-columns page-rows-contents page-layout-full">
+<div id="quarto-margin-sidebar" class="sidebar margin-sidebar">
+  <nav id="TOC" role="doc-toc" class="toc-active">
+    <h2 id="toc-title">Table of contents</h2>
+   
+  <ul>
+  <li><a href="#dynamic-grid-state-broadcasting" id="toc-dynamic-grid-state-broadcasting" class="nav-link active" data-scroll-target="#dynamic-grid-state-broadcasting">Dynamic Grid State Broadcasting</a>
+  <ul class="collapse">
+  <li><a href="#implementation-status" id="toc-implementation-status" class="nav-link" data-scroll-target="#implementation-status">Implementation Status</a>
+  <ul class="collapse">
+  <li><a href="#phase-1-broadcasting-infrastructure-complete" id="toc-phase-1-broadcasting-infrastructure-complete" class="nav-link" data-scroll-target="#phase-1-broadcasting-infrastructure-complete">✅ Phase 1: Broadcasting Infrastructure (Complete)</a></li>
+  <li><a href="#phase-2-walker-integration-in-progress" id="toc-phase-2-walker-integration-in-progress" class="nav-link" data-scroll-target="#phase-2-walker-integration-in-progress">🔄 Phase 2: Walker Integration (In Progress)</a></li>
+  <li><a href="#phase-3-simulation-integration-planned" id="toc-phase-3-simulation-integration-planned" class="nav-link" data-scroll-target="#phase-3-simulation-integration-planned">⏳ Phase 3: Simulation Integration (Planned)</a></li>
+  <li><a href="#phase-4-targets-pipeline-planned" id="toc-phase-4-targets-pipeline-planned" class="nav-link" data-scroll-target="#phase-4-targets-pipeline-planned">⏳ Phase 4: Targets Pipeline (Planned)</a></li>
+  <li><a href="#phase-5-interactive-dashboard-planned" id="toc-phase-5-interactive-dashboard-planned" class="nav-link" data-scroll-target="#phase-5-interactive-dashboard-planned">⏳ Phase 5: Interactive Dashboard (Planned)</a></li>
+  </ul></li>
+  <li><a href="#performance-analysis" id="toc-performance-analysis" class="nav-link" data-scroll-target="#performance-analysis">Performance Analysis</a>
+  <ul class="collapse">
+  <li><a href="#message-overhead" id="toc-message-overhead" class="nav-link" data-scroll-target="#message-overhead">Message Overhead</a></li>
+  <li><a href="#scalability" id="toc-scalability" class="nav-link" data-scroll-target="#scalability">Scalability</a></li>
+  </ul></li>
+  <li><a href="#when-to-use-each-mode" id="toc-when-to-use-each-mode" class="nav-link" data-scroll-target="#when-to-use-each-mode">When to Use Each Mode</a>
+  <ul class="collapse">
+  <li><a href="#use-static-mode-when" id="toc-use-static-mode-when" class="nav-link" data-scroll-target="#use-static-mode-when">Use Static Mode When</a></li>
+  <li><a href="#use-dynamic-mode-when" id="toc-use-dynamic-mode-when" class="nav-link" data-scroll-target="#use-dynamic-mode-when">Use Dynamic Mode When</a></li>
+  </ul></li>
+  <li><a href="#references" id="toc-references" class="nav-link" data-scroll-target="#references">References</a></li>
+  <li><a href="#summary" id="toc-summary" class="nav-link" data-scroll-target="#summary">Summary</a></li>
+  </ul></li>
+  </ul>
+</nav>
+</div>
+<main class="content column-page-left" id="quarto-document-content">
+
+<header id="title-block-header" class="quarto-title-block default">
+<div class="quarto-title">
+<h1 class="title">Dynamic Grid Broadcasting</h1>
+</div>
+
+
+
+<div class="quarto-title-meta column-page-left">
+
+    
+  
+    
+  </div>
+  
+
+
+</header>
+
+
+<section id="dynamic-grid-state-broadcasting" class="level1">
+<h1>Dynamic Grid State Broadcasting</h1>
+<blockquote class="blockquote">
+<p><strong>Status</strong>: Phase 1 Complete - Broadcasting infrastructure implemented <strong>Implementation</strong>: Core functions ready, simulation integration in progress <strong>Issue</strong>: <a href="https://github.com/JohnGavin/randomwalk/issues/51">#51</a></p>
+</blockquote>
+<div class="tabset-margin-container"></div><div class="panel-tabset">
+<ul class="nav nav-tabs" role="tablist"><li class="nav-item" role="presentation"><a class="nav-link active" id="tabset-1-1-tab" data-bs-toggle="tab" data-bs-target="#tabset-1-1" role="tab" aria-controls="tabset-1-1" aria-selected="true" href="">Overview</a></li><li class="nav-item" role="presentation"><a class="nav-link" id="tabset-1-2-tab" data-bs-toggle="tab" data-bs-target="#tabset-1-2" role="tab" aria-controls="tabset-1-2" aria-selected="false" href="">Implementation</a></li><li class="nav-item" role="presentation"><a class="nav-link" id="tabset-1-3-tab" data-bs-toggle="tab" data-bs-target="#tabset-1-3" role="tab" aria-controls="tabset-1-3" aria-selected="false" href="">Targets Simulations</a></li><li class="nav-item" role="presentation"><a class="nav-link" id="tabset-1-4-tab" data-bs-toggle="tab" data-bs-target="#tabset-1-4" role="tab" aria-controls="tabset-1-4" aria-selected="false" href="">Comparison Analysis</a></li><li class="nav-item" role="presentation"><a class="nav-link" id="tabset-1-5-tab" data-bs-toggle="tab" data-bs-target="#tabset-1-5" role="tab" aria-controls="tabset-1-5" aria-selected="false" href="">Interactive Dashboard</a></li></ul>
+<div class="tab-content">
+<div id="tabset-1-1" class="tab-pane active" role="tabpanel" aria-labelledby="tabset-1-1-tab">
+<section id="the-problem" class="level3">
+<h3 class="anchored" data-anchor-id="the-problem">The Problem</h3>
+<p>Currently, async workers receive a <strong>frozen copy</strong> of the grid that never updates:</p>
+<div class="cell">
+<details class="code-fold">
+<summary>Show code</summary>
+<div class="sourceCode cell-code" id="cb1"><pre class="sourceCode r code-with-copy"><code class="sourceCode r"><span id="cb1-1"><a href="#cb1-1" aria-hidden="true" tabindex="-1"></a><span class="co"># Current: Static snapshot</span></span>
+<span id="cb1-2"><a href="#cb1-2" aria-hidden="true" tabindex="-1"></a>controller<span class="sc">$</span><span class="fu">push</span>(</span>
+<span id="cb1-3"><a href="#cb1-3" aria-hidden="true" tabindex="-1"></a>  <span class="at">command =</span> <span class="fu">simulate_walker</span>(...),</span>
+<span id="cb1-4"><a href="#cb1-4" aria-hidden="true" tabindex="-1"></a>  <span class="at">data =</span> <span class="fu">list</span>(</span>
+<span id="cb1-5"><a href="#cb1-5" aria-hidden="true" tabindex="-1"></a>    <span class="at">walker_id =</span> i,</span>
+<span id="cb1-6"><a href="#cb1-6" aria-hidden="true" tabindex="-1"></a>    <span class="at">grid_state =</span> grid  <span class="co"># FROZEN - never updates!</span></span>
+<span id="cb1-7"><a href="#cb1-7" aria-hidden="true" tabindex="-1"></a>  )</span>
+<span id="cb1-8"><a href="#cb1-8" aria-hidden="true" tabindex="-1"></a>)</span></code><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></pre></div>
+</details>
+</div>
+<p><strong>Consequences:</strong> - ✅ Simple and fast - ❌ Workers don’t see each other’s movements - ❌ No collision detection - ❌ Different behavior from sync mode</p>
+</section>
+<section id="the-solution" class="level3">
+<h3 class="anchored" data-anchor-id="the-solution">The Solution</h3>
+<p>Workers communicate via <strong>publish-subscribe</strong> pattern:</p>
+<div class="cell">
+<details class="code-fold">
+<summary>Show code</summary>
+<div class="sourceCode cell-code" id="cb2"><pre class="sourceCode r code-with-copy"><code class="sourceCode r"><span id="cb2-1"><a href="#cb2-1" aria-hidden="true" tabindex="-1"></a><span class="co"># New: Dynamic broadcasting</span></span>
+<span id="cb2-2"><a href="#cb2-2" aria-hidden="true" tabindex="-1"></a><span class="co"># Worker 1 creates black pixel → broadcasts to all workers</span></span>
+<span id="cb2-3"><a href="#cb2-3" aria-hidden="true" tabindex="-1"></a><span class="fu">broadcast_black_pixel</span>(pub_socket, position, walker_id)</span>
+<span id="cb2-4"><a href="#cb2-4" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb2-5"><a href="#cb2-5" aria-hidden="true" tabindex="-1"></a><span class="co"># Worker 2-4 receive and apply update</span></span>
+<span id="cb2-6"><a href="#cb2-6" aria-hidden="true" tabindex="-1"></a>local_grid <span class="ot">&lt;-</span> <span class="fu">update_grid_from_broadcasts</span>(sub_socket, local_grid)</span></code><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></pre></div>
+</details>
+</div>
+</section>
+<section id="key-insight-minimal-broadcasting" class="level3">
+<h3 class="anchored" data-anchor-id="key-insight-minimal-broadcasting">Key Insight: Minimal Broadcasting</h3>
+<p><strong>Only broadcast when NEW black pixel is created!</strong></p>
+<table class="caption-top table">
+<thead>
+<tr class="header">
+<th>Event</th>
+<th>Broadcast?</th>
+<th>Why</th>
+</tr>
+</thead>
+<tbody>
+<tr class="odd">
+<td><strong>Walker detects black neighbor</strong></td>
+<td>✅ YES</td>
+<td>Creates new black pixel</td>
+</tr>
+<tr class="even">
+<td><strong>Started on black</strong></td>
+<td>❌ NO</td>
+<td>Already broadcast earlier</td>
+</tr>
+<tr class="odd">
+<td><strong>Max steps reached</strong></td>
+<td>❌ NO</td>
+<td>No pixel created</td>
+</tr>
+<tr class="even">
+<td><strong>Hit boundary</strong></td>
+<td>❌ NO</td>
+<td>No pixel created</td>
+</tr>
+</tbody>
+</table>
+<p><strong>Result:</strong> ~10-20 broadcasts per simulation (not 10,000!) 🎯</p>
+</section>
+<section id="architecture" class="level3">
+<h3 class="anchored" data-anchor-id="architecture">Architecture</h3>
+<p>``` ┌────────────────────────────────────────────┐ │ Main Process │ │ ├─ Publisher Socket (nanonext) │ │ └─ Crew Controller │ └────────────────────────────────────────────┘ │ │ pub/sub (nanonext NNG) │ ┌─────────┴──────┬──────────┬──────────┐ │ │ │ │ ┌───▼───┐ ┌──────▼──┐ ┌────▼────┐ ┌─▼──┐ │Worker1│ │Worker 2 │ │Worker 3 │ │… │ │Local │ │Local │ │Local │ │ │ │Grid │ │Grid │ │Grid │ │ │ │Sub │ │Sub │ │Sub │ │ │ └───────┘ └─────────┘ └─────────┘ └────┘ ```</p>
+</section>
+</div>
+<div id="tabset-1-2" class="tab-pane" role="tabpanel" aria-labelledby="tabset-1-2-tab">
+<section id="walker-logic-simplified" class="level3">
+<h3 class="anchored" data-anchor-id="walker-logic-simplified">Walker Logic (Simplified)</h3>
+<p>The complete walker logic with <strong>Step 2 removed</strong> for simplicity:</p>
+<div class="cell">
+<details class="code-fold">
+<summary>Show code</summary>
+<div class="sourceCode cell-code" id="cb3"><pre class="sourceCode r code-with-copy"><code class="sourceCode r"><span id="cb3-1"><a href="#cb3-1" aria-hidden="true" tabindex="-1"></a>simulate_walker_dynamic <span class="ot">&lt;-</span> <span class="cf">function</span>(walker_id, initial_grid,</span>
+<span id="cb3-2"><a href="#cb3-2" aria-hidden="true" tabindex="-1"></a>                                   pub_socket, sub_socket, ...) {</span>
+<span id="cb3-3"><a href="#cb3-3" aria-hidden="true" tabindex="-1"></a>  local_grid <span class="ot">&lt;-</span> initial_grid</span>
+<span id="cb3-4"><a href="#cb3-4" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb3-5"><a href="#cb3-5" aria-hidden="true" tabindex="-1"></a>  <span class="co"># ═══════════════════════════════════════════════════════</span></span>
+<span id="cb3-6"><a href="#cb3-6" aria-hidden="true" tabindex="-1"></a>  <span class="co"># STEP 0: Check starting position (before loop)</span></span>
+<span id="cb3-7"><a href="#cb3-7" aria-hidden="true" tabindex="-1"></a>  <span class="co"># ═══════════════════════════════════════════════════════</span></span>
+<span id="cb3-8"><a href="#cb3-8" aria-hidden="true" tabindex="-1"></a>  position <span class="ot">&lt;-</span> <span class="fu">sample_start_position</span>(grid_size)</span>
+<span id="cb3-9"><a href="#cb3-9" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb3-10"><a href="#cb3-10" aria-hidden="true" tabindex="-1"></a>  <span class="cf">if</span> (local_grid[position[<span class="dv">1</span>], position[<span class="dv">2</span>]] <span class="sc">==</span> <span class="st">"black"</span>) {</span>
+<span id="cb3-11"><a href="#cb3-11" aria-hidden="true" tabindex="-1"></a>    <span class="fu">return</span>(<span class="fu">list</span>(<span class="at">status =</span> <span class="st">"started_on_black"</span>, <span class="at">steps =</span> <span class="dv">0</span>))</span>
+<span id="cb3-12"><a href="#cb3-12" aria-hidden="true" tabindex="-1"></a>    <span class="co"># ❌ NO BROADCAST - pixel already broadcast earlier</span></span>
+<span id="cb3-13"><a href="#cb3-13" aria-hidden="true" tabindex="-1"></a>  }</span>
+<span id="cb3-14"><a href="#cb3-14" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb3-15"><a href="#cb3-15" aria-hidden="true" tabindex="-1"></a>  <span class="co"># ═══════════════════════════════════════════════════════</span></span>
+<span id="cb3-16"><a href="#cb3-16" aria-hidden="true" tabindex="-1"></a>  <span class="co"># MAIN LOOP (Steps 1-N)</span></span>
+<span id="cb3-17"><a href="#cb3-17" aria-hidden="true" tabindex="-1"></a>  <span class="co"># ═══════════════════════════════════════════════════════</span></span>
+<span id="cb3-18"><a href="#cb3-18" aria-hidden="true" tabindex="-1"></a>  <span class="cf">for</span> (step <span class="cf">in</span> <span class="dv">1</span><span class="sc">:</span>max_steps) {</span>
+<span id="cb3-19"><a href="#cb3-19" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb3-20"><a href="#cb3-20" aria-hidden="true" tabindex="-1"></a>    <span class="co"># ─────────────────────────────────────────────────────</span></span>
+<span id="cb3-21"><a href="#cb3-21" aria-hidden="true" tabindex="-1"></a>    <span class="co"># STEP 1: Pop ALL broadcasts, update local grid</span></span>
+<span id="cb3-22"><a href="#cb3-22" aria-hidden="true" tabindex="-1"></a>    <span class="co"># ─────────────────────────────────────────────────────</span></span>
+<span id="cb3-23"><a href="#cb3-23" aria-hidden="true" tabindex="-1"></a>    <span class="cf">while</span> (<span class="fu">has_messages</span>(sub_socket)) {</span>
+<span id="cb3-24"><a href="#cb3-24" aria-hidden="true" tabindex="-1"></a>      msg <span class="ot">&lt;-</span> <span class="fu">pop_message</span>(sub_socket)</span>
+<span id="cb3-25"><a href="#cb3-25" aria-hidden="true" tabindex="-1"></a>      local_grid[msg<span class="sc">$</span>position[<span class="dv">1</span>], msg<span class="sc">$</span>position[<span class="dv">2</span>]] <span class="ot">&lt;-</span> <span class="st">"black"</span></span>
+<span id="cb3-26"><a href="#cb3-26" aria-hidden="true" tabindex="-1"></a>    }</span>
+<span id="cb3-27"><a href="#cb3-27" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb3-28"><a href="#cb3-28" aria-hidden="true" tabindex="-1"></a>    <span class="co"># ─────────────────────────────────────────────────────</span></span>
+<span id="cb3-29"><a href="#cb3-29" aria-hidden="true" tabindex="-1"></a>    <span class="co"># STEP 2: Check neighbors for black pixels</span></span>
+<span id="cb3-30"><a href="#cb3-30" aria-hidden="true" tabindex="-1"></a>    <span class="co"># ─────────────────────────────────────────────────────</span></span>
+<span id="cb3-31"><a href="#cb3-31" aria-hidden="true" tabindex="-1"></a>    neighbors <span class="ot">&lt;-</span> <span class="fu">get_neighbors</span>(position, neighborhood)</span>
+<span id="cb3-32"><a href="#cb3-32" aria-hidden="true" tabindex="-1"></a>    has_black_neighbor <span class="ot">&lt;-</span> <span class="fu">any</span>(<span class="fu">is_black</span>(neighbors, local_grid))</span>
+<span id="cb3-33"><a href="#cb3-33" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb3-34"><a href="#cb3-34" aria-hidden="true" tabindex="-1"></a>    <span class="cf">if</span> (has_black_neighbor) {</span>
+<span id="cb3-35"><a href="#cb3-35" aria-hidden="true" tabindex="-1"></a>      <span class="co"># Current position becomes BLACK</span></span>
+<span id="cb3-36"><a href="#cb3-36" aria-hidden="true" tabindex="-1"></a>      local_grid[position[<span class="dv">1</span>], position[<span class="dv">2</span>]] <span class="ot">&lt;-</span> <span class="st">"black"</span></span>
+<span id="cb3-37"><a href="#cb3-37" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb3-38"><a href="#cb3-38" aria-hidden="true" tabindex="-1"></a>      <span class="co"># ✅ BROADCAST to all workers</span></span>
+<span id="cb3-39"><a href="#cb3-39" aria-hidden="true" tabindex="-1"></a>      <span class="fu">broadcast_black_pixel</span>(pub_socket, position, walker_id)</span>
+<span id="cb3-40"><a href="#cb3-40" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb3-41"><a href="#cb3-41" aria-hidden="true" tabindex="-1"></a>      <span class="fu">return</span>(<span class="fu">list</span>(<span class="at">status =</span> <span class="st">"black_neighbor_detected"</span>, <span class="at">steps =</span> step))</span>
+<span id="cb3-42"><a href="#cb3-42" aria-hidden="true" tabindex="-1"></a>    }</span>
+<span id="cb3-43"><a href="#cb3-43" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb3-44"><a href="#cb3-44" aria-hidden="true" tabindex="-1"></a>    <span class="co"># ─────────────────────────────────────────────────────</span></span>
+<span id="cb3-45"><a href="#cb3-45" aria-hidden="true" tabindex="-1"></a>    <span class="co"># STEP 3: Make move</span></span>
+<span id="cb3-46"><a href="#cb3-46" aria-hidden="true" tabindex="-1"></a>    <span class="co"># ─────────────────────────────────────────────────────</span></span>
+<span id="cb3-47"><a href="#cb3-47" aria-hidden="true" tabindex="-1"></a>    next_position <span class="ot">&lt;-</span> <span class="fu">choose_next_position</span>(position, local_grid)</span>
+<span id="cb3-48"><a href="#cb3-48" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb3-49"><a href="#cb3-49" aria-hidden="true" tabindex="-1"></a>    <span class="cf">if</span> (<span class="fu">is_boundary</span>(next_position, grid_size)) {</span>
+<span id="cb3-50"><a href="#cb3-50" aria-hidden="true" tabindex="-1"></a>      <span class="cf">if</span> (boundary <span class="sc">==</span> <span class="st">"terminate"</span>) {</span>
+<span id="cb3-51"><a href="#cb3-51" aria-hidden="true" tabindex="-1"></a>        <span class="fu">return</span>(<span class="fu">list</span>(<span class="at">status =</span> <span class="st">"boundary"</span>, <span class="at">steps =</span> step))</span>
+<span id="cb3-52"><a href="#cb3-52" aria-hidden="true" tabindex="-1"></a>        <span class="co"># ❌ NO BROADCAST</span></span>
+<span id="cb3-53"><a href="#cb3-53" aria-hidden="true" tabindex="-1"></a>      }</span>
+<span id="cb3-54"><a href="#cb3-54" aria-hidden="true" tabindex="-1"></a>      next_position <span class="ot">&lt;-</span> <span class="fu">handle_boundary</span>(next_position, boundary)</span>
+<span id="cb3-55"><a href="#cb3-55" aria-hidden="true" tabindex="-1"></a>    }</span>
+<span id="cb3-56"><a href="#cb3-56" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb3-57"><a href="#cb3-57" aria-hidden="true" tabindex="-1"></a>    position <span class="ot">&lt;-</span> next_position</span>
+<span id="cb3-58"><a href="#cb3-58" aria-hidden="true" tabindex="-1"></a>  }</span>
+<span id="cb3-59"><a href="#cb3-59" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb3-60"><a href="#cb3-60" aria-hidden="true" tabindex="-1"></a>  <span class="co"># Max steps - walker stops (no black pixel)</span></span>
+<span id="cb3-61"><a href="#cb3-61" aria-hidden="true" tabindex="-1"></a>  <span class="fu">return</span>(<span class="fu">list</span>(<span class="at">status =</span> <span class="st">"max_steps"</span>, <span class="at">steps =</span> max_steps))</span>
+<span id="cb3-62"><a href="#cb3-62" aria-hidden="true" tabindex="-1"></a>  <span class="co"># ❌ NO BROADCAST</span></span>
+<span id="cb3-63"><a href="#cb3-63" aria-hidden="true" tabindex="-1"></a>}</span></code><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></pre></div>
+</details>
+</div>
+</section>
+<section id="broadcasting-functions" class="level3">
+<h3 class="anchored" data-anchor-id="broadcasting-functions">Broadcasting Functions</h3>
+<p>Core infrastructure (implemented in <code>R/broadcasting.R</code>):</p>
+<div class="cell">
+<details class="code-fold">
+<summary>Show code</summary>
+<div class="sourceCode cell-code" id="cb4"><pre class="sourceCode r code-with-copy"><code class="sourceCode r"><span id="cb4-1"><a href="#cb4-1" aria-hidden="true" tabindex="-1"></a><span class="fu">library</span>(nanonext)</span>
+<span id="cb4-2"><a href="#cb4-2" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb4-3"><a href="#cb4-3" aria-hidden="true" tabindex="-1"></a><span class="co"># Initialize publisher (main process)</span></span>
+<span id="cb4-4"><a href="#cb4-4" aria-hidden="true" tabindex="-1"></a>pub_socket <span class="ot">&lt;-</span> <span class="fu">init_publisher_socket</span>(<span class="at">port =</span> <span class="dv">5555</span>)</span>
+<span id="cb4-5"><a href="#cb4-5" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb4-6"><a href="#cb4-6" aria-hidden="true" tabindex="-1"></a><span class="co"># Initialize subscriber (each worker)</span></span>
+<span id="cb4-7"><a href="#cb4-7" aria-hidden="true" tabindex="-1"></a>sub_socket <span class="ot">&lt;-</span> <span class="fu">init_subscriber_socket</span>(<span class="at">host =</span> <span class="st">"localhost"</span>, <span class="at">port =</span> <span class="dv">5555</span>)</span>
+<span id="cb4-8"><a href="#cb4-8" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb4-9"><a href="#cb4-9" aria-hidden="true" tabindex="-1"></a><span class="co"># Broadcast black pixel</span></span>
+<span id="cb4-10"><a href="#cb4-10" aria-hidden="true" tabindex="-1"></a><span class="fu">broadcast_black_pixel</span>(pub_socket, <span class="fu">c</span>(<span class="dv">50</span>, <span class="dv">50</span>), <span class="at">walker_id =</span> <span class="dv">1</span>)</span>
+<span id="cb4-11"><a href="#cb4-11" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb4-12"><a href="#cb4-12" aria-hidden="true" tabindex="-1"></a><span class="co"># Update local grid from all pending broadcasts</span></span>
+<span id="cb4-13"><a href="#cb4-13" aria-hidden="true" tabindex="-1"></a>local_grid <span class="ot">&lt;-</span> <span class="fu">update_grid_from_broadcasts</span>(sub_socket, local_grid)</span>
+<span id="cb4-14"><a href="#cb4-14" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb4-15"><a href="#cb4-15" aria-hidden="true" tabindex="-1"></a><span class="co"># Cleanup</span></span>
+<span id="cb4-16"><a href="#cb4-16" aria-hidden="true" tabindex="-1"></a><span class="fu">close_sockets</span>(pub_socket, sub_socket)</span></code><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></pre></div>
+</details>
+</div>
+</section>
+<section id="eventual-consistency" class="level3">
+<h3 class="anchored" data-anchor-id="eventual-consistency">Eventual Consistency</h3>
+<p><strong>Philosophy:</strong> “This is a simulation, not a bank”</p>
+<div class="cell">
+<details class="code-fold">
+<summary>Show code</summary>
+<div class="sourceCode cell-code" id="cb5"><pre class="sourceCode r code-with-copy"><code class="sourceCode r"><span id="cb5-1"><a href="#cb5-1" aria-hidden="true" tabindex="-1"></a><span class="co"># Workers use best-efforts synchronization</span></span>
+<span id="cb5-2"><a href="#cb5-2" aria-hidden="true" tabindex="-1"></a><span class="cf">for</span> (step <span class="cf">in</span> <span class="dv">1</span><span class="sc">:</span>max_steps) {</span>
+<span id="cb5-3"><a href="#cb5-3" aria-hidden="true" tabindex="-1"></a>  <span class="co"># 1. Pop ALL pending messages</span></span>
+<span id="cb5-4"><a href="#cb5-4" aria-hidden="true" tabindex="-1"></a>  local_grid <span class="ot">&lt;-</span> <span class="fu">update_grid_from_broadcasts</span>(sub_socket, local_grid)</span>
+<span id="cb5-5"><a href="#cb5-5" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb5-6"><a href="#cb5-6" aria-hidden="true" tabindex="-1"></a>  <span class="co"># 2. Make move with current state (might be slightly stale)</span></span>
+<span id="cb5-7"><a href="#cb5-7" aria-hidden="true" tabindex="-1"></a>  position <span class="ot">&lt;-</span> <span class="fu">make_move</span>(position, local_grid)</span>
+<span id="cb5-8"><a href="#cb5-8" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb5-9"><a href="#cb5-9" aria-hidden="true" tabindex="-1"></a>  <span class="co"># 3. Broadcast if black pixel created</span></span>
+<span id="cb5-10"><a href="#cb5-10" aria-hidden="true" tabindex="-1"></a>  <span class="cf">if</span> (created_black_pixel) {</span>
+<span id="cb5-11"><a href="#cb5-11" aria-hidden="true" tabindex="-1"></a>    <span class="fu">broadcast_black_pixel</span>(pub_socket, position)</span>
+<span id="cb5-12"><a href="#cb5-12" aria-hidden="true" tabindex="-1"></a>  }</span>
+<span id="cb5-13"><a href="#cb5-13" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb5-14"><a href="#cb5-14" aria-hidden="true" tabindex="-1"></a>  <span class="co"># 4. Any staleness resolves on next iteration</span></span>
+<span id="cb5-15"><a href="#cb5-15" aria-hidden="true" tabindex="-1"></a>}</span></code><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></pre></div>
+</details>
+</div>
+<p><strong>Acceptable trade-offs:</strong> - ⚠️ Worker might have stale state for 1 iteration - ⚠️ Possible duplicate broadcast (rare) - ✅ System remains stable - ✅ Eventually consistent</p>
+</section>
+</div>
+<div id="tabset-1-3" class="tab-pane" role="tabpanel" aria-labelledby="tabset-1-3-tab">
+<section id="pre-computed-results" class="level3">
+<h3 class="anchored" data-anchor-id="pre-computed-results">Pre-Computed Results</h3>
+<p>Pre-computed simulations at three scales (targets-based):</p>
+<div class="cell">
+<details class="code-fold">
+<summary>Show code</summary>
+<div class="sourceCode cell-code" id="cb6"><pre class="sourceCode r code-with-copy"><code class="sourceCode r"><span id="cb6-1"><a href="#cb6-1" aria-hidden="true" tabindex="-1"></a><span class="co"># In _targets.R</span></span>
+<span id="cb6-2"><a href="#cb6-2" aria-hidden="true" tabindex="-1"></a><span class="fu">library</span>(targets)</span>
+<span id="cb6-3"><a href="#cb6-3" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb6-4"><a href="#cb6-4" aria-hidden="true" tabindex="-1"></a><span class="fu">list</span>(</span>
+<span id="cb6-5"><a href="#cb6-5" aria-hidden="true" tabindex="-1"></a>  <span class="co"># Small: Quick demonstration (500 steps)</span></span>
+<span id="cb6-6"><a href="#cb6-6" aria-hidden="true" tabindex="-1"></a>  <span class="fu">tar_target</span>(</span>
+<span id="cb6-7"><a href="#cb6-7" aria-hidden="true" tabindex="-1"></a>    sim_dynamic_small,</span>
+<span id="cb6-8"><a href="#cb6-8" aria-hidden="true" tabindex="-1"></a>    <span class="fu">run_simulation</span>(</span>
+<span id="cb6-9"><a href="#cb6-9" aria-hidden="true" tabindex="-1"></a>      <span class="at">grid_size =</span> <span class="dv">50</span>,</span>
+<span id="cb6-10"><a href="#cb6-10" aria-hidden="true" tabindex="-1"></a>      <span class="at">n_walkers =</span> <span class="dv">10</span>,</span>
+<span id="cb6-11"><a href="#cb6-11" aria-hidden="true" tabindex="-1"></a>      <span class="at">workers =</span> <span class="dv">2</span>,</span>
+<span id="cb6-12"><a href="#cb6-12" aria-hidden="true" tabindex="-1"></a>      <span class="at">sync_mode =</span> <span class="st">"dynamic"</span>,</span>
+<span id="cb6-13"><a href="#cb6-13" aria-hidden="true" tabindex="-1"></a>      <span class="at">max_steps =</span> <span class="dv">500</span></span>
+<span id="cb6-14"><a href="#cb6-14" aria-hidden="true" tabindex="-1"></a>    )</span>
+<span id="cb6-15"><a href="#cb6-15" aria-hidden="true" tabindex="-1"></a>  ),</span>
+<span id="cb6-16"><a href="#cb6-16" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb6-17"><a href="#cb6-17" aria-hidden="true" tabindex="-1"></a>  <span class="co"># Medium: Balanced performance (4000 steps)</span></span>
+<span id="cb6-18"><a href="#cb6-18" aria-hidden="true" tabindex="-1"></a>  <span class="fu">tar_target</span>(</span>
+<span id="cb6-19"><a href="#cb6-19" aria-hidden="true" tabindex="-1"></a>    sim_dynamic_medium,</span>
+<span id="cb6-20"><a href="#cb6-20" aria-hidden="true" tabindex="-1"></a>    <span class="fu">run_simulation</span>(</span>
+<span id="cb6-21"><a href="#cb6-21" aria-hidden="true" tabindex="-1"></a>      <span class="at">grid_size =</span> <span class="dv">100</span>,</span>
+<span id="cb6-22"><a href="#cb6-22" aria-hidden="true" tabindex="-1"></a>      <span class="at">n_walkers =</span> <span class="dv">20</span>,</span>
+<span id="cb6-23"><a href="#cb6-23" aria-hidden="true" tabindex="-1"></a>      <span class="at">workers =</span> <span class="dv">4</span>,</span>
+<span id="cb6-24"><a href="#cb6-24" aria-hidden="true" tabindex="-1"></a>      <span class="at">sync_mode =</span> <span class="st">"dynamic"</span>,</span>
+<span id="cb6-25"><a href="#cb6-25" aria-hidden="true" tabindex="-1"></a>      <span class="at">max_steps =</span> <span class="dv">4000</span></span>
+<span id="cb6-26"><a href="#cb6-26" aria-hidden="true" tabindex="-1"></a>    )</span>
+<span id="cb6-27"><a href="#cb6-27" aria-hidden="true" tabindex="-1"></a>  ),</span>
+<span id="cb6-28"><a href="#cb6-28" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb6-29"><a href="#cb6-29" aria-hidden="true" tabindex="-1"></a>  <span class="co"># Large: Stress test (12000 steps)</span></span>
+<span id="cb6-30"><a href="#cb6-30" aria-hidden="true" tabindex="-1"></a>  <span class="fu">tar_target</span>(</span>
+<span id="cb6-31"><a href="#cb6-31" aria-hidden="true" tabindex="-1"></a>    sim_dynamic_large,</span>
+<span id="cb6-32"><a href="#cb6-32" aria-hidden="true" tabindex="-1"></a>    <span class="fu">run_simulation</span>(</span>
+<span id="cb6-33"><a href="#cb6-33" aria-hidden="true" tabindex="-1"></a>      <span class="at">grid_size =</span> <span class="dv">200</span>,</span>
+<span id="cb6-34"><a href="#cb6-34" aria-hidden="true" tabindex="-1"></a>      <span class="at">n_walkers =</span> <span class="dv">50</span>,</span>
+<span id="cb6-35"><a href="#cb6-35" aria-hidden="true" tabindex="-1"></a>      <span class="at">workers =</span> <span class="dv">8</span>,</span>
+<span id="cb6-36"><a href="#cb6-36" aria-hidden="true" tabindex="-1"></a>      <span class="at">sync_mode =</span> <span class="st">"dynamic"</span>,</span>
+<span id="cb6-37"><a href="#cb6-37" aria-hidden="true" tabindex="-1"></a>      <span class="at">max_steps =</span> <span class="dv">12000</span></span>
+<span id="cb6-38"><a href="#cb6-38" aria-hidden="true" tabindex="-1"></a>    )</span>
+<span id="cb6-39"><a href="#cb6-39" aria-hidden="true" tabindex="-1"></a>  ),</span>
+<span id="cb6-40"><a href="#cb6-40" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb6-41"><a href="#cb6-41" aria-hidden="true" tabindex="-1"></a>  <span class="co"># Static mode comparisons</span></span>
+<span id="cb6-42"><a href="#cb6-42" aria-hidden="true" tabindex="-1"></a>  <span class="fu">tar_target</span>(</span>
+<span id="cb6-43"><a href="#cb6-43" aria-hidden="true" tabindex="-1"></a>    sim_static_small,</span>
+<span id="cb6-44"><a href="#cb6-44" aria-hidden="true" tabindex="-1"></a>    <span class="fu">run_simulation</span>(</span>
+<span id="cb6-45"><a href="#cb6-45" aria-hidden="true" tabindex="-1"></a>      <span class="at">grid_size =</span> <span class="dv">50</span>, <span class="at">n_walkers =</span> <span class="dv">10</span>, <span class="at">workers =</span> <span class="dv">2</span>,</span>
+<span id="cb6-46"><a href="#cb6-46" aria-hidden="true" tabindex="-1"></a>      <span class="at">sync_mode =</span> <span class="st">"static"</span>, <span class="at">max_steps =</span> <span class="dv">500</span></span>
+<span id="cb6-47"><a href="#cb6-47" aria-hidden="true" tabindex="-1"></a>    )</span>
+<span id="cb6-48"><a href="#cb6-48" aria-hidden="true" tabindex="-1"></a>  ),</span>
+<span id="cb6-49"><a href="#cb6-49" aria-hidden="true" tabindex="-1"></a>  <span class="fu">tar_target</span>(</span>
+<span id="cb6-50"><a href="#cb6-50" aria-hidden="true" tabindex="-1"></a>    sim_static_medium,</span>
+<span id="cb6-51"><a href="#cb6-51" aria-hidden="true" tabindex="-1"></a>    <span class="fu">run_simulation</span>(</span>
+<span id="cb6-52"><a href="#cb6-52" aria-hidden="true" tabindex="-1"></a>      <span class="at">grid_size =</span> <span class="dv">100</span>, <span class="at">n_walkers =</span> <span class="dv">20</span>, <span class="at">workers =</span> <span class="dv">4</span>,</span>
+<span id="cb6-53"><a href="#cb6-53" aria-hidden="true" tabindex="-1"></a>      <span class="at">sync_mode =</span> <span class="st">"static"</span>, <span class="at">max_steps =</span> <span class="dv">4000</span></span>
+<span id="cb6-54"><a href="#cb6-54" aria-hidden="true" tabindex="-1"></a>    )</span>
+<span id="cb6-55"><a href="#cb6-55" aria-hidden="true" tabindex="-1"></a>  ),</span>
+<span id="cb6-56"><a href="#cb6-56" aria-hidden="true" tabindex="-1"></a>  <span class="fu">tar_target</span>(</span>
+<span id="cb6-57"><a href="#cb6-57" aria-hidden="true" tabindex="-1"></a>    sim_static_large,</span>
+<span id="cb6-58"><a href="#cb6-58" aria-hidden="true" tabindex="-1"></a>    <span class="fu">run_simulation</span>(</span>
+<span id="cb6-59"><a href="#cb6-59" aria-hidden="true" tabindex="-1"></a>      <span class="at">grid_size =</span> <span class="dv">200</span>, <span class="at">n_walkers =</span> <span class="dv">50</span>, <span class="at">workers =</span> <span class="dv">8</span>,</span>
+<span id="cb6-60"><a href="#cb6-60" aria-hidden="true" tabindex="-1"></a>      <span class="at">sync_mode =</span> <span class="st">"static"</span>, <span class="at">max_steps =</span> <span class="dv">12000</span></span>
+<span id="cb6-61"><a href="#cb6-61" aria-hidden="true" tabindex="-1"></a>    )</span>
+<span id="cb6-62"><a href="#cb6-62" aria-hidden="true" tabindex="-1"></a>  )</span>
+<span id="cb6-63"><a href="#cb6-63" aria-hidden="true" tabindex="-1"></a>)</span></code><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></pre></div>
+</details>
+</div>
+</section>
+<section id="load-and-visualize" class="level3">
+<h3 class="anchored" data-anchor-id="load-and-visualize">Load and Visualize</h3>
+<div class="cell">
+<details class="code-fold">
+<summary>Show code</summary>
+<div class="sourceCode cell-code" id="cb7"><pre class="sourceCode r code-with-copy"><code class="sourceCode r"><span id="cb7-1"><a href="#cb7-1" aria-hidden="true" tabindex="-1"></a><span class="co"># Load pre-computed results</span></span>
+<span id="cb7-2"><a href="#cb7-2" aria-hidden="true" tabindex="-1"></a>targets<span class="sc">::</span><span class="fu">tar_load</span>(<span class="fu">c</span>(sim_static_small, sim_dynamic_small))</span>
+<span id="cb7-3"><a href="#cb7-3" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb7-4"><a href="#cb7-4" aria-hidden="true" tabindex="-1"></a><span class="co"># Compare grids side-by-side</span></span>
+<span id="cb7-5"><a href="#cb7-5" aria-hidden="true" tabindex="-1"></a><span class="fu">library</span>(patchwork)</span>
+<span id="cb7-6"><a href="#cb7-6" aria-hidden="true" tabindex="-1"></a><span class="fu">plot_grid</span>(sim_static_small<span class="sc">$</span>grid) <span class="sc">+</span></span>
+<span id="cb7-7"><a href="#cb7-7" aria-hidden="true" tabindex="-1"></a>  <span class="fu">ggtitle</span>(<span class="st">"Static Mode"</span>) <span class="sc">+</span></span>
+<span id="cb7-8"><a href="#cb7-8" aria-hidden="true" tabindex="-1"></a><span class="fu">plot_grid</span>(sim_dynamic_small<span class="sc">$</span>grid) <span class="sc">+</span></span>
+<span id="cb7-9"><a href="#cb7-9" aria-hidden="true" tabindex="-1"></a>  <span class="fu">ggtitle</span>(<span class="st">"Dynamic Mode"</span>)</span>
+<span id="cb7-10"><a href="#cb7-10" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb7-11"><a href="#cb7-11" aria-hidden="true" tabindex="-1"></a><span class="co"># Statistics comparison</span></span>
+<span id="cb7-12"><a href="#cb7-12" aria-hidden="true" tabindex="-1"></a><span class="fu">library</span>(dplyr)</span>
+<span id="cb7-13"><a href="#cb7-13" aria-hidden="true" tabindex="-1"></a><span class="fu">bind_rows</span>(</span>
+<span id="cb7-14"><a href="#cb7-14" aria-hidden="true" tabindex="-1"></a>  sim_static_small<span class="sc">$</span>statistics <span class="sc">%&gt;%</span> <span class="fu">mutate</span>(<span class="at">mode =</span> <span class="st">"static"</span>),</span>
+<span id="cb7-15"><a href="#cb7-15" aria-hidden="true" tabindex="-1"></a>  sim_dynamic_small<span class="sc">$</span>statistics <span class="sc">%&gt;%</span> <span class="fu">mutate</span>(<span class="at">mode =</span> <span class="st">"dynamic"</span>)</span>
+<span id="cb7-16"><a href="#cb7-16" aria-hidden="true" tabindex="-1"></a>) <span class="sc">%&gt;%</span></span>
+<span id="cb7-17"><a href="#cb7-17" aria-hidden="true" tabindex="-1"></a>  <span class="fu">select</span>(mode, black_pixels, total_steps, elapsed_time_secs)</span></code><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></pre></div>
+</details>
+</div>
+</section>
+<section id="expected-results" class="level3">
+<h3 class="anchored" data-anchor-id="expected-results">Expected Results</h3>
+<table class="caption-top table">
+<thead>
+<tr class="header">
+<th>Scale</th>
+<th>Mode</th>
+<th>Black Pixels</th>
+<th>Collisions</th>
+<th>Time</th>
+<th>Overhead</th>
+</tr>
+</thead>
+<tbody>
+<tr class="odd">
+<td>Small</td>
+<td>Static</td>
+<td>~80</td>
+<td>0</td>
+<td>0.5s</td>
+<td>-</td>
+</tr>
+<tr class="even">
+<td>Small</td>
+<td>Dynamic</td>
+<td>~70</td>
+<td>~3</td>
+<td>0.56s</td>
+<td>+12%</td>
+</tr>
+<tr class="odd">
+<td>Medium</td>
+<td>Static</td>
+<td>~350</td>
+<td>0</td>
+<td>3.2s</td>
+<td>-</td>
+</tr>
+<tr class="even">
+<td>Medium</td>
+<td>Dynamic</td>
+<td>~310</td>
+<td>~12</td>
+<td>3.6s</td>
+<td>+13%</td>
+</tr>
+<tr class="odd">
+<td>Large</td>
+<td>Static</td>
+<td>~1200</td>
+<td>0</td>
+<td>18s</td>
+<td>-</td>
+</tr>
+<tr class="even">
+<td>Large</td>
+<td>Dynamic</td>
+<td>~1050</td>
+<td>~45</td>
+<td>20s</td>
+<td>+11%</td>
+</tr>
+</tbody>
+</table>
+<p><strong>Observations:</strong> - Dynamic mode: Fewer black pixels (collisions terminate walkers early) - Modest overhead: ~11-13% slower (broadcasting cost) - Realistic behavior: Walkers actually interact</p>
+</section>
+</div>
+<div id="tabset-1-4" class="tab-pane" role="tabpanel" aria-labelledby="tabset-1-4-tab">
+<section id="performance-metrics" class="level3">
+<h3 class="anchored" data-anchor-id="performance-metrics">Performance Metrics</h3>
+<div class="cell">
+<details class="code-fold">
+<summary>Show code</summary>
+<div class="sourceCode cell-code" id="cb8"><pre class="sourceCode r code-with-copy"><code class="sourceCode r"><span id="cb8-1"><a href="#cb8-1" aria-hidden="true" tabindex="-1"></a><span class="co"># Performance comparison</span></span>
+<span id="cb8-2"><a href="#cb8-2" aria-hidden="true" tabindex="-1"></a>compare_performance <span class="ot">&lt;-</span> <span class="cf">function</span>(static_result, dynamic_result) {</span>
+<span id="cb8-3"><a href="#cb8-3" aria-hidden="true" tabindex="-1"></a>  <span class="fu">tibble</span>(</span>
+<span id="cb8-4"><a href="#cb8-4" aria-hidden="true" tabindex="-1"></a>    <span class="at">metric =</span> <span class="fu">c</span>(</span>
+<span id="cb8-5"><a href="#cb8-5" aria-hidden="true" tabindex="-1"></a>      <span class="st">"Black pixels"</span>,</span>
+<span id="cb8-6"><a href="#cb8-6" aria-hidden="true" tabindex="-1"></a>      <span class="st">"Total steps"</span>,</span>
+<span id="cb8-7"><a href="#cb8-7" aria-hidden="true" tabindex="-1"></a>      <span class="st">"Elapsed time (s)"</span>,</span>
+<span id="cb8-8"><a href="#cb8-8" aria-hidden="true" tabindex="-1"></a>      <span class="st">"Steps per second"</span>,</span>
+<span id="cb8-9"><a href="#cb8-9" aria-hidden="true" tabindex="-1"></a>      <span class="st">"Collisions detected"</span>,</span>
+<span id="cb8-10"><a href="#cb8-10" aria-hidden="true" tabindex="-1"></a>      <span class="st">"Overhead (%)"</span></span>
+<span id="cb8-11"><a href="#cb8-11" aria-hidden="true" tabindex="-1"></a>    ),</span>
+<span id="cb8-12"><a href="#cb8-12" aria-hidden="true" tabindex="-1"></a>    <span class="at">static =</span> <span class="fu">c</span>(</span>
+<span id="cb8-13"><a href="#cb8-13" aria-hidden="true" tabindex="-1"></a>      static_result<span class="sc">$</span>statistics<span class="sc">$</span>black_pixels,</span>
+<span id="cb8-14"><a href="#cb8-14" aria-hidden="true" tabindex="-1"></a>      static_result<span class="sc">$</span>statistics<span class="sc">$</span>total_steps,</span>
+<span id="cb8-15"><a href="#cb8-15" aria-hidden="true" tabindex="-1"></a>      static_result<span class="sc">$</span>statistics<span class="sc">$</span>elapsed_time_secs,</span>
+<span id="cb8-16"><a href="#cb8-16" aria-hidden="true" tabindex="-1"></a>      static_result<span class="sc">$</span>statistics<span class="sc">$</span>total_steps <span class="sc">/</span> static_result<span class="sc">$</span>statistics<span class="sc">$</span>elapsed_time_secs,</span>
+<span id="cb8-17"><a href="#cb8-17" aria-hidden="true" tabindex="-1"></a>      <span class="dv">0</span>,  <span class="co"># No collisions in static mode</span></span>
+<span id="cb8-18"><a href="#cb8-18" aria-hidden="true" tabindex="-1"></a>      <span class="dv">0</span></span>
+<span id="cb8-19"><a href="#cb8-19" aria-hidden="true" tabindex="-1"></a>    ),</span>
+<span id="cb8-20"><a href="#cb8-20" aria-hidden="true" tabindex="-1"></a>    <span class="at">dynamic =</span> <span class="fu">c</span>(</span>
+<span id="cb8-21"><a href="#cb8-21" aria-hidden="true" tabindex="-1"></a>      dynamic_result<span class="sc">$</span>statistics<span class="sc">$</span>black_pixels,</span>
+<span id="cb8-22"><a href="#cb8-22" aria-hidden="true" tabindex="-1"></a>      dynamic_result<span class="sc">$</span>statistics<span class="sc">$</span>total_steps,</span>
+<span id="cb8-23"><a href="#cb8-23" aria-hidden="true" tabindex="-1"></a>      dynamic_result<span class="sc">$</span>statistics<span class="sc">$</span>elapsed_time_secs,</span>
+<span id="cb8-24"><a href="#cb8-24" aria-hidden="true" tabindex="-1"></a>      dynamic_result<span class="sc">$</span>statistics<span class="sc">$</span>total_steps <span class="sc">/</span> dynamic_result<span class="sc">$</span>statistics<span class="sc">$</span>elapsed_time_secs,</span>
+<span id="cb8-25"><a href="#cb8-25" aria-hidden="true" tabindex="-1"></a>      <span class="fu">sum</span>(dynamic_result<span class="sc">$</span>statistics<span class="sc">$</span>termination_reasons <span class="sc">==</span> <span class="st">"black_neighbor_detected"</span>),</span>
+<span id="cb8-26"><a href="#cb8-26" aria-hidden="true" tabindex="-1"></a>      ((dynamic_result<span class="sc">$</span>statistics<span class="sc">$</span>elapsed_time_secs <span class="sc">/</span></span>
+<span id="cb8-27"><a href="#cb8-27" aria-hidden="true" tabindex="-1"></a>        static_result<span class="sc">$</span>statistics<span class="sc">$</span>elapsed_time_secs) <span class="sc">-</span> <span class="dv">1</span>) <span class="sc">*</span> <span class="dv">100</span></span>
+<span id="cb8-28"><a href="#cb8-28" aria-hidden="true" tabindex="-1"></a>    )</span>
+<span id="cb8-29"><a href="#cb8-29" aria-hidden="true" tabindex="-1"></a>  )</span>
+<span id="cb8-30"><a href="#cb8-30" aria-hidden="true" tabindex="-1"></a>}</span>
+<span id="cb8-31"><a href="#cb8-31" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb8-32"><a href="#cb8-32" aria-hidden="true" tabindex="-1"></a><span class="co"># Run comparison</span></span>
+<span id="cb8-33"><a href="#cb8-33" aria-hidden="true" tabindex="-1"></a><span class="fu">compare_performance</span>(sim_static_small, sim_dynamic_small)</span></code><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></pre></div>
+</details>
+</div>
+</section>
+<section id="clustering-patterns" class="level3">
+<h3 class="anchored" data-anchor-id="clustering-patterns">Clustering Patterns</h3>
+<div class="cell">
+<details class="code-fold">
+<summary>Show code</summary>
+<div class="sourceCode cell-code" id="cb9"><pre class="sourceCode r code-with-copy"><code class="sourceCode r"><span id="cb9-1"><a href="#cb9-1" aria-hidden="true" tabindex="-1"></a><span class="co"># Analyze spatial clustering</span></span>
+<span id="cb9-2"><a href="#cb9-2" aria-hidden="true" tabindex="-1"></a><span class="fu">library</span>(spatstat)</span>
+<span id="cb9-3"><a href="#cb9-3" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb9-4"><a href="#cb9-4" aria-hidden="true" tabindex="-1"></a>analyze_clustering <span class="ot">&lt;-</span> <span class="cf">function</span>(grid) {</span>
+<span id="cb9-5"><a href="#cb9-5" aria-hidden="true" tabindex="-1"></a>  <span class="co"># Convert grid to point pattern</span></span>
+<span id="cb9-6"><a href="#cb9-6" aria-hidden="true" tabindex="-1"></a>  black_positions <span class="ot">&lt;-</span> <span class="fu">which</span>(grid <span class="sc">==</span> <span class="st">"black"</span>, <span class="at">arr.ind =</span> <span class="cn">TRUE</span>)</span>
+<span id="cb9-7"><a href="#cb9-7" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb9-8"><a href="#cb9-8" aria-hidden="true" tabindex="-1"></a>  ppp_data <span class="ot">&lt;-</span> <span class="fu">ppp</span>(</span>
+<span id="cb9-9"><a href="#cb9-9" aria-hidden="true" tabindex="-1"></a>    <span class="at">x =</span> black_positions[, <span class="dv">2</span>],</span>
+<span id="cb9-10"><a href="#cb9-10" aria-hidden="true" tabindex="-1"></a>    <span class="at">y =</span> black_positions[, <span class="dv">1</span>],</span>
+<span id="cb9-11"><a href="#cb9-11" aria-hidden="true" tabindex="-1"></a>    <span class="at">window =</span> <span class="fu">owin</span>(<span class="fu">c</span>(<span class="dv">1</span>, <span class="fu">ncol</span>(grid)), <span class="fu">c</span>(<span class="dv">1</span>, <span class="fu">nrow</span>(grid)))</span>
+<span id="cb9-12"><a href="#cb9-12" aria-hidden="true" tabindex="-1"></a>  )</span>
+<span id="cb9-13"><a href="#cb9-13" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb9-14"><a href="#cb9-14" aria-hidden="true" tabindex="-1"></a>  <span class="co"># Calculate Ripley's K function</span></span>
+<span id="cb9-15"><a href="#cb9-15" aria-hidden="true" tabindex="-1"></a>  k_func <span class="ot">&lt;-</span> <span class="fu">Kest</span>(ppp_data)</span>
+<span id="cb9-16"><a href="#cb9-16" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb9-17"><a href="#cb9-17" aria-hidden="true" tabindex="-1"></a>  <span class="co"># Plot</span></span>
+<span id="cb9-18"><a href="#cb9-18" aria-hidden="true" tabindex="-1"></a>  <span class="fu">plot</span>(k_func, <span class="at">main =</span> <span class="st">"Clustering Analysis"</span>)</span>
+<span id="cb9-19"><a href="#cb9-19" aria-hidden="true" tabindex="-1"></a>}</span>
+<span id="cb9-20"><a href="#cb9-20" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb9-21"><a href="#cb9-21" aria-hidden="true" tabindex="-1"></a><span class="co"># Compare clustering</span></span>
+<span id="cb9-22"><a href="#cb9-22" aria-hidden="true" tabindex="-1"></a><span class="fu">par</span>(<span class="at">mfrow =</span> <span class="fu">c</span>(<span class="dv">1</span>, <span class="dv">2</span>))</span>
+<span id="cb9-23"><a href="#cb9-23" aria-hidden="true" tabindex="-1"></a><span class="fu">analyze_clustering</span>(sim_static_small<span class="sc">$</span>grid)</span>
+<span id="cb9-24"><a href="#cb9-24" aria-hidden="true" tabindex="-1"></a><span class="fu">analyze_clustering</span>(sim_dynamic_small<span class="sc">$</span>grid)</span></code><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></pre></div>
+</details>
+</div>
+</section>
+</div>
+<div id="tabset-1-5" class="tab-pane" role="tabpanel" aria-labelledby="tabset-1-5-tab">
+<section id="shinylive-app" class="level3">
+<h3 class="anchored" data-anchor-id="shinylive-app">Shinylive App</h3>
+<blockquote class="blockquote">
+<p><strong>Note:</strong> Interactive Shiny app will be added in Phase 3</p>
+</blockquote>
+<p>The dashboard will include:</p>
+<p><strong>Inputs:</strong> - Grid size: 20-200 (slider) - Number of walkers: 1-max (slider) - Number of workers: 0-8 (slider) - <strong>Sync mode: “static” vs “dynamic” (radio)</strong> ← New - Neighborhood: “4-hood” vs “8-hood” - Boundary: “terminate” vs “wrap” - Max steps: 100-5000</p>
+<p><strong>Outputs:</strong> - Grid visualization (interactive plotly) - Statistics table - Black pixels - <strong>Collisions</strong> ← New (dynamic only) - Steps, time - Performance metrics - Elapsed time - Speedup - <strong>Broadcasting overhead</strong> ← New</p>
+<p><strong>Features:</strong> - Run button: Execute simulation - Compare button: Run static + dynamic side-by-side - Download results - Reset</p>
+</section>
+<section id="launch-dashboard" class="level3">
+<h3 class="anchored" data-anchor-id="launch-dashboard">Launch Dashboard</h3>
+<p>```{r eval=FALSE} # Will be available after Phase 3 implementation shiny::runApp(“inst/shiny/dashboard_dynamic”) ```</p>
+</section>
+</div>
+</div>
+</div>
+<section id="implementation-status" class="level2">
+<h2 class="anchored" data-anchor-id="implementation-status">Implementation Status</h2>
+<section id="phase-1-broadcasting-infrastructure-complete" class="level3">
+<h3 class="anchored" data-anchor-id="phase-1-broadcasting-infrastructure-complete">✅ Phase 1: Broadcasting Infrastructure (Complete)</h3>
+<ul class="task-list">
+<li><label><input type="checkbox" checked=""><code>R/broadcasting.R</code> with socket functions</label></li>
+<li><label><input type="checkbox" checked=""><code>init_publisher_socket()</code> - Create publisher</label></li>
+<li><label><input type="checkbox" checked=""><code>init_subscriber_socket()</code> - Create subscriber</label></li>
+<li><label><input type="checkbox" checked=""><code>broadcast_black_pixel()</code> - Send updates</label></li>
+<li><label><input type="checkbox" checked=""><code>update_grid_from_broadcasts()</code> - Receive and apply</label></li>
+<li><label><input type="checkbox" checked=""><code>close_sockets()</code> - Cleanup</label></li>
+<li><label><input type="checkbox" checked="">Complete documentation (roxygen2)</label></li>
+</ul>
+</section>
+<section id="phase-2-walker-integration-in-progress" class="level3">
+<h3 class="anchored" data-anchor-id="phase-2-walker-integration-in-progress">🔄 Phase 2: Walker Integration (In Progress)</h3>
+<ul class="task-list">
+<li><label><input type="checkbox" checked=""><code>R/walker_dynamic.R</code> created</label></li>
+<li><label><input type="checkbox" checked=""><code>simulate_walker_dynamic()</code> - Core walker logic</label></li>
+<li><label><input type="checkbox" checked="">Simplified 3-step logic (Step 2 removed)</label></li>
+<li><label><input type="checkbox" checked="">Helper functions (get_neighbors, etc.)</label></li>
+<li><label><input type="checkbox">Integration with crew worker processes</label></li>
+<li><label><input type="checkbox">Socket serialization handling</label></li>
+</ul>
+</section>
+<section id="phase-3-simulation-integration-planned" class="level3">
+<h3 class="anchored" data-anchor-id="phase-3-simulation-integration-planned">⏳ Phase 3: Simulation Integration (Planned)</h3>
+<ul class="task-list">
+<li><label><input type="checkbox">Add <code>sync_mode</code> parameter to <code>run_simulation()</code></label></li>
+<li><label><input type="checkbox">Create <code>run_simulation_async_dynamic()</code> function</label></li>
+<li><label><input type="checkbox">Handle socket initialization in main process</label></li>
+<li><label><input type="checkbox">Distribute sockets to workers</label></li>
+<li><label><input type="checkbox">Collect results and compile statistics</label></li>
+<li><label><input type="checkbox">Add collision statistics to output</label></li>
+</ul>
+</section>
+<section id="phase-4-targets-pipeline-planned" class="level3">
+<h3 class="anchored" data-anchor-id="phase-4-targets-pipeline-planned">⏳ Phase 4: Targets Pipeline (Planned)</h3>
+<ul class="task-list">
+<li><label><input type="checkbox">Add dynamic simulation targets to <code>_targets.R</code></label></li>
+<li><label><input type="checkbox">Pre-compute small/medium/large simulations</label></li>
+<li><label><input type="checkbox">Generate comparison plots</label></li>
+<li><label><input type="checkbox">Update vignette with actual results</label></li>
+</ul>
+</section>
+<section id="phase-5-interactive-dashboard-planned" class="level3">
+<h3 class="anchored" data-anchor-id="phase-5-interactive-dashboard-planned">⏳ Phase 5: Interactive Dashboard (Planned)</h3>
+<ul class="task-list">
+<li><label><input type="checkbox">Create <code>inst/shiny/dashboard_dynamic/app.R</code></label></li>
+<li><label><input type="checkbox">Add sync_mode selector</label></li>
+<li><label><input type="checkbox">Display collision statistics</label></li>
+<li><label><input type="checkbox">Show broadcasting overhead</label></li>
+<li><label><input type="checkbox">Export to shinylive</label></li>
+</ul>
+</section>
+</section>
+<section id="performance-analysis" class="level2">
+<h2 class="anchored" data-anchor-id="performance-analysis">Performance Analysis</h2>
+<section id="message-overhead" class="level3">
+<h3 class="anchored" data-anchor-id="message-overhead">Message Overhead</h3>
+<table class="caption-top table">
+<thead>
+<tr class="header">
+<th>Approach</th>
+<th>Messages/Sim</th>
+<th>Overhead</th>
+</tr>
+</thead>
+<tbody>
+<tr class="odd">
+<td><strong>Broadcast every step</strong> (wrong)</td>
+<td>~10,000</td>
+<td>Network saturated</td>
+</tr>
+<tr class="even">
+<td><strong>Dynamic broadcasting</strong> (correct)</td>
+<td>~10-20</td>
+<td>Minimal (~12%)</td>
+</tr>
+<tr class="odd">
+<td><strong>Static snapshot</strong> (current)</td>
+<td>0</td>
+<td>None (unrealistic)</td>
+</tr>
+</tbody>
+</table>
+</section>
+<section id="scalability" class="level3">
+<h3 class="anchored" data-anchor-id="scalability">Scalability</h3>
+<div class="cell">
+<details class="code-fold">
+<summary>Show code</summary>
+<div class="sourceCode cell-code" id="cb10"><pre class="sourceCode r code-with-copy"><code class="sourceCode r"><span id="cb10-1"><a href="#cb10-1" aria-hidden="true" tabindex="-1"></a><span class="co"># Benchmark scaling with worker count</span></span>
+<span id="cb10-2"><a href="#cb10-2" aria-hidden="true" tabindex="-1"></a>workers_range <span class="ot">&lt;-</span> <span class="fu">c</span>(<span class="dv">0</span>, <span class="dv">1</span>, <span class="dv">2</span>, <span class="dv">4</span>, <span class="dv">8</span>)</span>
+<span id="cb10-3"><a href="#cb10-3" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb10-4"><a href="#cb10-4" aria-hidden="true" tabindex="-1"></a>results <span class="ot">&lt;-</span> <span class="fu">lapply</span>(workers_range, <span class="cf">function</span>(n_workers) {</span>
+<span id="cb10-5"><a href="#cb10-5" aria-hidden="true" tabindex="-1"></a>  <span class="fu">system.time</span>({</span>
+<span id="cb10-6"><a href="#cb10-6" aria-hidden="true" tabindex="-1"></a>    <span class="fu">run_simulation</span>(</span>
+<span id="cb10-7"><a href="#cb10-7" aria-hidden="true" tabindex="-1"></a>      <span class="at">grid_size =</span> <span class="dv">100</span>,</span>
+<span id="cb10-8"><a href="#cb10-8" aria-hidden="true" tabindex="-1"></a>      <span class="at">n_walkers =</span> <span class="dv">20</span>,</span>
+<span id="cb10-9"><a href="#cb10-9" aria-hidden="true" tabindex="-1"></a>      <span class="at">workers =</span> n_workers,</span>
+<span id="cb10-10"><a href="#cb10-10" aria-hidden="true" tabindex="-1"></a>      <span class="at">sync_mode =</span> <span class="st">"dynamic"</span></span>
+<span id="cb10-11"><a href="#cb10-11" aria-hidden="true" tabindex="-1"></a>    )</span>
+<span id="cb10-12"><a href="#cb10-12" aria-hidden="true" tabindex="-1"></a>  })[<span class="st">"elapsed"</span>]</span>
+<span id="cb10-13"><a href="#cb10-13" aria-hidden="true" tabindex="-1"></a>})</span>
+<span id="cb10-14"><a href="#cb10-14" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb10-15"><a href="#cb10-15" aria-hidden="true" tabindex="-1"></a><span class="fu">plot</span>(workers_range, results,</span>
+<span id="cb10-16"><a href="#cb10-16" aria-hidden="true" tabindex="-1"></a>     <span class="at">xlab =</span> <span class="st">"Number of Workers"</span>,</span>
+<span id="cb10-17"><a href="#cb10-17" aria-hidden="true" tabindex="-1"></a>     <span class="at">ylab =</span> <span class="st">"Time (seconds)"</span>,</span>
+<span id="cb10-18"><a href="#cb10-18" aria-hidden="true" tabindex="-1"></a>     <span class="at">main =</span> <span class="st">"Dynamic Broadcasting Scalability"</span>)</span></code><button title="Copy to Clipboard" class="code-copy-button"><i class="bi"></i></button></pre></div>
+</details>
+</div>
+</section>
+</section>
+<section id="when-to-use-each-mode" class="level2">
+<h2 class="anchored" data-anchor-id="when-to-use-each-mode">When to Use Each Mode</h2>
+<section id="use-static-mode-when" class="level3">
+<h3 class="anchored" data-anchor-id="use-static-mode-when">Use Static Mode When</h3>
+<ul>
+<li>✅ Maximum performance critical</li>
+<li>✅ Walker interactions not important</li>
+<li>✅ Quick prototyping</li>
+<li>✅ Reproducibility critical</li>
+</ul>
+</section>
+<section id="use-dynamic-mode-when" class="level3">
+<h3 class="anchored" data-anchor-id="use-dynamic-mode-when">Use Dynamic Mode When</h3>
+<ul>
+<li>✅ Realistic interactions required</li>
+<li>✅ Collision detection important</li>
+<li>✅ Studying emergent behavior</li>
+<li>✅ Educational demonstrations</li>
+<li>✅ Performance overhead acceptable</li>
+</ul>
+</section>
+</section>
+<section id="references" class="level2">
+<h2 class="anchored" data-anchor-id="references">References</h2>
+<ul>
+<li><a href="https://github.com/JohnGavin/randomwalk/issues/51">Issue #51</a> - Complete implementation plan</li>
+<li><a href="dashboard_async.html">Async Dashboard</a> - Static snapshot implementation</li>
+<li><code>?run_simulation</code> - Main simulation function</li>
+<li><a href="https://shikokuchuo.net/nanonext/">nanonext Package</a> - NNG sockets for R</li>
+<li><a href="https://wlandau.github.io/crew/">crew Package</a> - Distributed workers</li>
+</ul>
+</section>
+<section id="summary" class="level2">
+<h2 class="anchored" data-anchor-id="summary">Summary</h2>
+<p>Dynamic broadcasting enables realistic walker interactions in async simulations:</p>
+<p>✅ <strong>Minimal overhead</strong> - Only ~10-20 broadcasts per simulation ✅ <strong>Eventual consistency</strong> - Best-efforts approach, not perfect sync ✅ <strong>Simple protocol</strong> - Pop messages, check neighbors, broadcast ✅ <strong>Robust</strong> - Handles race conditions through repeated updates</p>
+<p><strong>Key insight:</strong> Workers only care about <strong>obstacles</strong> (black pixels), not walker positions. This makes the implementation dramatically simpler and more efficient.</p>
+<p><strong>Status:</strong> Phase 1 (infrastructure) complete. Phases 2-5 in progress.</p>
+</section>
+</section>
+
+</main>
+<!-- /main column -->
+<script id="quarto-html-after-body" type="application/javascript">
+  window.document.addEventListener("DOMContentLoaded", function (event) {
+    const icon = "";
+    const anchorJS = new window.AnchorJS();
+    anchorJS.options = {
+      placement: 'right',
+      icon: icon
+    };
+    anchorJS.add('.anchored');
+    const isCodeAnnotation = (el) => {
+      for (const clz of el.classList) {
+        if (clz.startsWith('code-annotation-')) {                     
+          return true;
+        }
+      }
+      return false;
+    }
+    const onCopySuccess = function(e) {
+      // button target
+      const button = e.trigger;
+      // don't keep focus
+      button.blur();
+      // flash "checked"
+      button.classList.add('code-copy-button-checked');
+      var currentTitle = button.getAttribute("title");
+      button.setAttribute("title", "Copied!");
+      let tooltip;
+      if (window.bootstrap) {
+        button.setAttribute("data-bs-toggle", "tooltip");
+        button.setAttribute("data-bs-placement", "left");
+        button.setAttribute("data-bs-title", "Copied!");
+        tooltip = new bootstrap.Tooltip(button, 
+          { trigger: "manual", 
+            customClass: "code-copy-button-tooltip",
+            offset: [0, -8]});
+        tooltip.show();    
+      }
+      setTimeout(function() {
+        if (tooltip) {
+          tooltip.hide();
+          button.removeAttribute("data-bs-title");
+          button.removeAttribute("data-bs-toggle");
+          button.removeAttribute("data-bs-placement");
+        }
+        button.setAttribute("title", currentTitle);
+        button.classList.remove('code-copy-button-checked');
+      }, 1000);
+      // clear code selection
+      e.clearSelection();
+    }
+    const getTextToCopy = function(trigger) {
+        const codeEl = trigger.previousElementSibling.cloneNode(true);
+        for (const childEl of codeEl.children) {
+          if (isCodeAnnotation(childEl)) {
+            childEl.remove();
+          }
+        }
+        return codeEl.innerText;
+    }
+    const clipboard = new window.ClipboardJS('.code-copy-button:not([data-in-quarto-modal])', {
+      text: getTextToCopy
+    });
+    clipboard.on('success', onCopySuccess);
+    if (window.document.getElementById('quarto-embedded-source-code-modal')) {
+      const clipboardModal = new window.ClipboardJS('.code-copy-button[data-in-quarto-modal]', {
+        text: getTextToCopy,
+        container: window.document.getElementById('quarto-embedded-source-code-modal')
+      });
+      clipboardModal.on('success', onCopySuccess);
+    }
+      var localhostRegex = new RegExp(/^(?:http|https):\/\/localhost\:?[0-9]*\//);
+      var mailtoRegex = new RegExp(/^mailto:/);
+        var filterRegex = new RegExp('/' + window.location.host + '/');
+      var isInternal = (href) => {
+          return filterRegex.test(href) || localhostRegex.test(href) || mailtoRegex.test(href);
+      }
+      // Inspect non-navigation links and adorn them if external
+     var links = window.document.querySelectorAll('a[href]:not(.nav-link):not(.navbar-brand):not(.toc-action):not(.sidebar-link):not(.sidebar-item-toggle):not(.pagination-link):not(.no-external):not([aria-hidden]):not(.dropdown-item):not(.quarto-navigation-tool):not(.about-link)');
+      for (var i=0; i<links.length; i++) {
+        const link = links[i];
+        if (!isInternal(link.href)) {
+          // undo the damage that might have been done by quarto-nav.js in the case of
+          // links that we want to consider external
+          if (link.dataset.originalHref !== undefined) {
+            link.href = link.dataset.originalHref;
+          }
+        }
+      }
+    function tippyHover(el, contentFn, onTriggerFn, onUntriggerFn) {
+      const config = {
+        allowHTML: true,
+        maxWidth: 500,
+        delay: 100,
+        arrow: false,
+        appendTo: function(el) {
+            return el.parentElement;
+        },
+        interactive: true,
+        interactiveBorder: 10,
+        theme: 'quarto',
+        placement: 'bottom-start',
+      };
+      if (contentFn) {
+        config.content = contentFn;
+      }
+      if (onTriggerFn) {
+        config.onTrigger = onTriggerFn;
+      }
+      if (onUntriggerFn) {
+        config.onUntrigger = onUntriggerFn;
+      }
+      window.tippy(el, config); 
+    }
+    const noterefs = window.document.querySelectorAll('a[role="doc-noteref"]');
+    for (var i=0; i<noterefs.length; i++) {
+      const ref = noterefs[i];
+      tippyHover(ref, function() {
+        // use id or data attribute instead here
+        let href = ref.getAttribute('data-footnote-href') || ref.getAttribute('href');
+        try { href = new URL(href).hash; } catch {}
+        const id = href.replace(/^#\/?/, "");
+        const note = window.document.getElementById(id);
+        if (note) {
+          return note.innerHTML;
+        } else {
+          return "";
+        }
+      });
+    }
+    const xrefs = window.document.querySelectorAll('a.quarto-xref');
+    const processXRef = (id, note) => {
+      // Strip column container classes
+      const stripColumnClz = (el) => {
+        el.classList.remove("page-full", "page-columns");
+        if (el.children) {
+          for (const child of el.children) {
+            stripColumnClz(child);
+          }
+        }
+      }
+      stripColumnClz(note)
+      if (id === null || id.startsWith('sec-')) {
+        // Special case sections, only their first couple elements
+        const container = document.createElement("div");
+        if (note.children && note.children.length > 2) {
+          container.appendChild(note.children[0].cloneNode(true));
+          for (let i = 1; i < note.children.length; i++) {
+            const child = note.children[i];
+            if (child.tagName === "P" && child.innerText === "") {
+              continue;
+            } else {
+              container.appendChild(child.cloneNode(true));
+              break;
+            }
+          }
+          if (window.Quarto?.typesetMath) {
+            window.Quarto.typesetMath(container);
+          }
+          return container.innerHTML
+        } else {
+          if (window.Quarto?.typesetMath) {
+            window.Quarto.typesetMath(note);
+          }
+          return note.innerHTML;
+        }
+      } else {
+        // Remove any anchor links if they are present
+        const anchorLink = note.querySelector('a.anchorjs-link');
+        if (anchorLink) {
+          anchorLink.remove();
+        }
+        if (window.Quarto?.typesetMath) {
+          window.Quarto.typesetMath(note);
+        }
+        if (note.classList.contains("callout")) {
+          return note.outerHTML;
+        } else {
+          return note.innerHTML;
+        }
+      }
+    }
+    for (var i=0; i<xrefs.length; i++) {
+      const xref = xrefs[i];
+      tippyHover(xref, undefined, function(instance) {
+        instance.disable();
+        let url = xref.getAttribute('href');
+        let hash = undefined; 
+        if (url.startsWith('#')) {
+          hash = url;
+        } else {
+          try { hash = new URL(url).hash; } catch {}
+        }
+        if (hash) {
+          const id = hash.replace(/^#\/?/, "");
+          const note = window.document.getElementById(id);
+          if (note !== null) {
+            try {
+              const html = processXRef(id, note.cloneNode(true));
+              instance.setContent(html);
+            } finally {
+              instance.enable();
+              instance.show();
+            }
+          } else {
+            // See if we can fetch this
+            fetch(url.split('#')[0])
+            .then(res => res.text())
+            .then(html => {
+              const parser = new DOMParser();
+              const htmlDoc = parser.parseFromString(html, "text/html");
+              const note = htmlDoc.getElementById(id);
+              if (note !== null) {
+                const html = processXRef(id, note);
+                instance.setContent(html);
+              } 
+            }).finally(() => {
+              instance.enable();
+              instance.show();
+            });
+          }
+        } else {
+          // See if we can fetch a full url (with no hash to target)
+          // This is a special case and we should probably do some content thinning / targeting
+          fetch(url)
+          .then(res => res.text())
+          .then(html => {
+            const parser = new DOMParser();
+            const htmlDoc = parser.parseFromString(html, "text/html");
+            const note = htmlDoc.querySelector('main.content');
+            if (note !== null) {
+              // This should only happen for chapter cross references
+              // (since there is no id in the URL)
+              // remove the first header
+              if (note.children.length > 0 && note.children[0].tagName === "HEADER") {
+                note.children[0].remove();
+              }
+              const html = processXRef(null, note);
+              instance.setContent(html);
+            } 
+          }).finally(() => {
+            instance.enable();
+            instance.show();
+          });
+        }
+      }, function(instance) {
+      });
+    }
+        let selectedAnnoteEl;
+        const selectorForAnnotation = ( cell, annotation) => {
+          let cellAttr = 'data-code-cell="' + cell + '"';
+          let lineAttr = 'data-code-annotation="' +  annotation + '"';
+          const selector = 'span[' + cellAttr + '][' + lineAttr + ']';
+          return selector;
+        }
+        const selectCodeLines = (annoteEl) => {
+          const doc = window.document;
+          const targetCell = annoteEl.getAttribute("data-target-cell");
+          const targetAnnotation = annoteEl.getAttribute("data-target-annotation");
+          const annoteSpan = window.document.querySelector(selectorForAnnotation(targetCell, targetAnnotation));
+          const lines = annoteSpan.getAttribute("data-code-lines").split(",");
+          const lineIds = lines.map((line) => {
+            return targetCell + "-" + line;
+          })
+          let top = null;
+          let height = null;
+          let parent = null;
+          if (lineIds.length > 0) {
+              //compute the position of the single el (top and bottom and make a div)
+              const el = window.document.getElementById(lineIds[0]);
+              top = el.offsetTop;
+              height = el.offsetHeight;
+              parent = el.parentElement.parentElement;
+            if (lineIds.length > 1) {
+              const lastEl = window.document.getElementById(lineIds[lineIds.length - 1]);
+              const bottom = lastEl.offsetTop + lastEl.offsetHeight;
+              height = bottom - top;
+            }
+            if (top !== null && height !== null && parent !== null) {
+              // cook up a div (if necessary) and position it 
+              let div = window.document.getElementById("code-annotation-line-highlight");
+              if (div === null) {
+                div = window.document.createElement("div");
+                div.setAttribute("id", "code-annotation-line-highlight");
+                div.style.position = 'absolute';
+                parent.appendChild(div);
+              }
+              div.style.top = top - 2 + "px";
+              div.style.height = height + 4 + "px";
+              div.style.left = 0;
+              let gutterDiv = window.document.getElementById("code-annotation-line-highlight-gutter");
+              if (gutterDiv === null) {
+                gutterDiv = window.document.createElement("div");
+                gutterDiv.setAttribute("id", "code-annotation-line-highlight-gutter");
+                gutterDiv.style.position = 'absolute';
+                const codeCell = window.document.getElementById(targetCell);
+                const gutter = codeCell.querySelector('.code-annotation-gutter');
+                gutter.appendChild(gutterDiv);
+              }
+              gutterDiv.style.top = top - 2 + "px";
+              gutterDiv.style.height = height + 4 + "px";
+            }
+            selectedAnnoteEl = annoteEl;
+          }
+        };
+        const unselectCodeLines = () => {
+          const elementsIds = ["code-annotation-line-highlight", "code-annotation-line-highlight-gutter"];
+          elementsIds.forEach((elId) => {
+            const div = window.document.getElementById(elId);
+            if (div) {
+              div.remove();
+            }
+          });
+          selectedAnnoteEl = undefined;
+        };
+          // Handle positioning of the toggle
+      window.addEventListener(
+        "resize",
+        throttle(() => {
+          elRect = undefined;
+          if (selectedAnnoteEl) {
+            selectCodeLines(selectedAnnoteEl);
+          }
+        }, 10)
+      );
+      function throttle(fn, ms) {
+      let throttle = false;
+      let timer;
+        return (...args) => {
+          if(!throttle) { // first call gets through
+              fn.apply(this, args);
+              throttle = true;
+          } else { // all the others get throttled
+              if(timer) clearTimeout(timer); // cancel #2
+              timer = setTimeout(() => {
+                fn.apply(this, args);
+                timer = throttle = false;
+              }, ms);
+          }
+        };
+      }
+        // Attach click handler to the DT
+        const annoteDls = window.document.querySelectorAll('dt[data-target-cell]');
+        for (const annoteDlNode of annoteDls) {
+          annoteDlNode.addEventListener('click', (event) => {
+            const clickedEl = event.target;
+            if (clickedEl !== selectedAnnoteEl) {
+              unselectCodeLines();
+              const activeEl = window.document.querySelector('dt[data-target-cell].code-annotation-active');
+              if (activeEl) {
+                activeEl.classList.remove('code-annotation-active');
+              }
+              selectCodeLines(clickedEl);
+              clickedEl.classList.add('code-annotation-active');
+            } else {
+              // Unselect the line
+              unselectCodeLines();
+              clickedEl.classList.remove('code-annotation-active');
+            }
+          });
+        }
+    const findCites = (el) => {
+      const parentEl = el.parentElement;
+      if (parentEl) {
+        const cites = parentEl.dataset.cites;
+        if (cites) {
+          return {
+            el,
+            cites: cites.split(' ')
+          };
+        } else {
+          return findCites(el.parentElement)
+        }
+      } else {
+        return undefined;
+      }
+    };
+    var bibliorefs = window.document.querySelectorAll('a[role="doc-biblioref"]');
+    for (var i=0; i<bibliorefs.length; i++) {
+      const ref = bibliorefs[i];
+      const citeInfo = findCites(ref);
+      if (citeInfo) {
+        tippyHover(citeInfo.el, function() {
+          var popup = window.document.createElement('div');
+          citeInfo.cites.forEach(function(cite) {
+            var citeDiv = window.document.createElement('div');
+            citeDiv.classList.add('hanging-indent');
+            citeDiv.classList.add('csl-entry');
+            var biblioDiv = window.document.getElementById('ref-' + cite);
+            if (biblioDiv) {
+              citeDiv.innerHTML = biblioDiv.innerHTML;
+            }
+            popup.appendChild(citeDiv);
+          });
+          return popup.innerHTML;
+        });
+      }
+    }
+  });
+  </script>
+</div> <!-- /content -->
+
+
+
+
+</body></html>

--- a/vignettes/dynamic_broadcasting.qmd
+++ b/vignettes/dynamic_broadcasting.qmd
@@ -16,7 +16,7 @@ knitr::opts_chunk$set(
   fig.width = 10,
   fig.height = 6
 )
-library(randomwalk)
+# Note: library(randomwalk) not needed - vignette is documentation only
 ```
 
 # Dynamic Grid State Broadcasting


### PR DESCRIPTION
## Summary

Fixes #94 - Three vignette links were broken on the website because HTML files were missing.

## Problem

Broken links on website:
- https://johngavin.github.io/randomwalk/articles/dashboard.html ✅ (existed)
- https://johngavin.github.io/randomwalk/articles/dashboard_async.html ❌ (missing)
- https://johngavin.github.io/randomwalk/articles/dynamic_broadcasting.html ❌ (missing)

**Root cause**: pkgdown requires pre-built HTML files in `vignettes/` directory to include them on the website.

## Solution

Pre-built both missing vignettes using Quarto:

```bash
cd vignettes
quarto render dashboard_async.qmd
quarto render dynamic_broadcasting.qmd
```

**Files added:**
- `vignettes/dashboard_async.html` (29K)
- `vignettes/dynamic_broadcasting.html` (78K)

**Files modified:**
- `vignettes/dynamic_broadcasting.qmd` - Removed `library(randomwalk)` from setup chunk (not needed, vignette is documentation only)

## Expected Result

After pkgdown rebuilds:
- ✅ All three vignette links will work
- ✅ Users can access complete documentation
- ✅ Consistent with existing vignettes (dashboard.html, telemetry.html)

## Testing

- ✅ Both HTML files build successfully with Quarto
- ✅ Files exist in vignettes/ directory
- ⏳ Will verify links work after pkgdown deployment

## Priority

**High** - Broken documentation links hurt usability

## Session Log

See `R/setup/fix_issue_94_broken_vignette_links.R` for full command history.
