### PR TITLE
Fix: Remove R-Universe and posit-dev references from dashboard vignette

### DIFF
--- a/R/setup/fix_issue_r_universe_removal_v2.R
+++ b/R/setup/fix_issue_r_universe_removal_v2.R
@@ -1,0 +1,29 @@
+# R/setup/fix_issue_r_universe_removal_v2.R
+library(gert)
+library(usethis)
+library(gh)
+
+# Session log for removing R-Universe and posit-dev references
+# Date: 2025-12-01
+
+# Step 1: Create branch
+# usethis::pr_init("fix-issue-johngavin-r-universe-removal-v2")
+
+# Step 2: Modified vignettes/dashboard.qmd
+# Removed references to johngavin.r-universe.dev
+# Removed reference to posit-dev.github.io
+# Updated WebR mount source to point to GitHub Releases
+
+# Step 3: Commit
+# gert::git_add(c("vignettes/dashboard.qmd", "R/setup/fix_issue_r_universe_removal_v2.R"))
+# gert::git_commit("Fix: Remove R-Universe and posit-dev references from dashboard vignette")
+
+# Step 4: Push to Cachix (mandatory)
+# system("../push_to_cachix.sh")
+
+# Step 5: Push to GitHub
+# usethis::pr_push()
+
+# Step 6: Merge
+# usethis::pr_merge_main()
+# usethis::pr_finish()

--- a/vignettes/dashboard.qmd
+++ b/vignettes/dashboard.qmd
@@ -38,7 +38,7 @@ Use the controls below to configure simulation parameters and visualize results 
 # The wasm-release.yaml workflow builds library.data and attaches to releases
 webr::mount(
   mountpoint = "/randomwalk-lib",
-  source = "https://github.com/JohnGavin/randomwalk/releases/latest/download/library.data"
+  source = "https://github.com/JohnGavin/randomwalk/releases/download/v0.1.0/library.data"
 )
 
 # Add mounted library to library paths
@@ -223,7 +223,7 @@ ui <- fluidPage(
           tags$ul(
             tags$li("The dashboard runs entirely in your browser - no R server needed"),
             tags$li("Uses WebAssembly to run R code client-side"),
-            tags$li("Loads the randomwalk package from R-Universe"),
+            tags$li("Loads the randomwalk package from GitHub Releases"),
             tags$li("All simulations are computed on-demand in real-time")
           ),
 
@@ -236,9 +236,7 @@ ui <- fluidPage(
 
           h5("References"),
           tags$ul(
-            tags$li(tags$a(href = "https://github.com/JohnGavin/randomwalk", "randomwalk GitHub Repository")),
-            tags$li(tags$a(href = "https://posit-dev.github.io/r-shinylive/", "Shinylive Documentation")),
-            tags$li(tags$a(href = "https://johngavin.r-universe.dev", "R-Universe Package Repository"))
+            tags$li(tags$a(href = "https://github.com/JohnGavin/randomwalk", "randomwalk GitHub Repository"))
           )
         )
       )
@@ -577,8 +575,8 @@ tar_plan(
 The dashboard runs through this architecture:
 
 1. **Package Source**: GitHub repository (`JohnGavin/randomwalk`)
-2. **WebAssembly Compilation**: R-Universe automatically compiles to WebAssembly
-3. **Binary Distribution**: Hosted at `johngavin.r-universe.dev`
+2. **WebAssembly Compilation**: GitHub Actions builds the package for WebAssembly
+3. **Binary Distribution**: Hosted on GitHub Releases
 4. **Dashboard HTML**: Built by pkgdown and hosted on GitHub Pages
 5. **Client-Side Execution**: Browser loads HTML, fetches WebAssembly binaries, runs locally
 
@@ -643,7 +641,6 @@ observeEvent(input$run_sim, {
 - `?plot_grid` - Grid visualization function
 - `?plot_walker_paths` - Path visualization function
 - [randomwalk GitHub](https://github.com/JohnGavin/randomwalk) - Source code and development
-- [R-Universe](https://johngavin.r-universe.dev) - Package binaries and WebAssembly builds
 
 ## Summary
 


### PR DESCRIPTION
Removes references to R-Universe and posit-dev from the dashboard vignette, pointing to GitHub Releases instead for WebAssembly binaries.