### PR TITLE
Fix: Optimize CI caching by pushing dev env and sequencing jobs

### DIFF
--- a/.github/workflows/nix-ci.yml
+++ b/.github/workflows/nix-ci.yml
@@ -78,6 +78,12 @@ jobs:
           nix-store -qR --include-outputs result | cachix push johngavin
           echo "✓ Package cached successfully"
 
+      - name: Push dev environment to johngavin cache
+        run: |
+          echo "Pushing dev environment to johngavin cachix..."
+          nix-store -qR --include-outputs $(nix-instantiate default-ci.nix) | cachix push johngavin
+          echo "✓ Dev environment cached successfully"
+
       - name: Verify package structure
         run: |
           echo "Package structure:"
@@ -230,6 +236,7 @@ jobs:
   # Job 5: Check nix file generation
   check-nix-generation:
     name: Verify Nix Files
+    needs: build-and-cache-package
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Optimizes the Nix CI workflow to prevent redundant compilation on Linux runners.

1. Caches the full development environment (`default-ci.nix`) in the build job.
2. Sequences the verification job to depend on the build job, ensuring it uses the cached environment instead of rebuilding from source.

This addresses the issue where pushing from macOS to Cachix was not accelerating Linux CI builds.