### PR TITLE
Fix: Repair dashboard deployment issues and revert CI optimization

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -15,3 +15,5 @@
 ^archive$
 ^CLAUDE_CONTEXT\.md$
 ^PROJECT_INFO\.md$
+^push_to_cachix\.sh$
+^.*\.sh$

--- a/.github/workflows/nix-ci.yml
+++ b/.github/workflows/nix-ci.yml
@@ -78,12 +78,6 @@ jobs:
           nix-store -qR --include-outputs result | cachix push johngavin
           echo "✓ Package cached successfully"
 
-      - name: Push dev environment to johngavin cache
-        run: |
-          echo "Pushing dev environment to johngavin cachix..."
-          nix-store -qR --include-outputs $(nix-instantiate default-ci.nix) | cachix push johngavin
-          echo "✓ Dev environment cached successfully"
-
       - name: Verify package structure
         run: |
           echo "Package structure:"
@@ -236,7 +230,6 @@ jobs:
   # Job 5: Check nix file generation
   check-nix-generation:
     name: Verify Nix Files
-    needs: build-and-cache-package
     runs-on: ubuntu-latest
 
     steps:

--- a/vignettes/dashboard.qmd
+++ b/vignettes/dashboard.qmd
@@ -1,5 +1,5 @@
 ---
-title: "Interactive Dashboard"
+title: "Hello Interactive Dashboard"
 format:
   html:
     code-fold: true
@@ -34,16 +34,21 @@ Use the controls below to configure simulation parameters and visualize results 
 #| standalone: true
 #| viewerHeight: 900
 
-# Mount WebAssembly file system from GitHub release
-# The wasm-release.yaml workflow builds library.data and attaches to releases
-eval(parse(text = 'webr::mount(mountpoint = "/randomwalk-lib", source = "https://github.com/JohnGavin/randomwalk/releases/download/v0.1.0/library.data")'))
+# Mount WebAssembly file system from local path (deployed to docs/wasm)
+# This avoids CORS issues by using the same origin
+webr::mount(
+  mountpoint = "/randomwalk-lib",
+  source = "../wasm/library.data"
+)
 
 # Add mounted library to library paths
 .libPaths(c("/randomwalk-lib", .libPaths()))
 
 # Install ggplot2 dependencies explicitly from webR repository
 # Use /tmp for installation since it's writable
-eval(parse(text = 'webr::install(c("munsell", "colorspace", "farver", "labeling", "viridisLite", "RColorBrewer", "scales", "tibble", "ggplot2"), lib = "/tmp/webr-libs")'))
+webr::install(c("munsell", "colorspace", "farver", "labeling", "viridisLite",
+                 "RColorBrewer", "scales", "tibble", "ggplot2"),
+               lib = "/tmp/webr-libs")
 
 # Add the tmp library to the path
 .libPaths(c("/tmp/webr-libs", .libPaths()))
@@ -53,7 +58,7 @@ library(shiny)
 library(ggplot2)
 
 # Load randomwalk from mounted library
-eval(parse(text = "library(randomwalk)"))
+library(randomwalk)
 
 # Define UI
 ui <- fluidPage(

--- a/vignettes/dashboard_async.qmd
+++ b/vignettes/dashboard_async.qmd
@@ -1,5 +1,5 @@
 ---
-title: "Async Random Walk Simulation Dashboard"
+title: "Hello Async Random Walk Simulation Dashboard"
 format:
   html:
     code-fold: true
@@ -23,16 +23,21 @@ The dashboard runs entirely in your browser using WebAssembly.
 #| standalone: true
 #| viewerHeight: 900
 
-# Mount WebAssembly file system from GitHub release
-# The wasm-release.yaml workflow builds library.data and attaches to releases
-eval(parse(text = 'webr::mount(mountpoint = "/randomwalk-lib", source = "https://github.com/JohnGavin/randomwalk/releases/download/v0.1.0/library.data")'))
+# Mount WebAssembly file system from local path (deployed to docs/wasm)
+# This avoids CORS issues by using the same origin
+webr::mount(
+  mountpoint = "/randomwalk-lib",
+  source = "../wasm/library.data"
+)
 
 # Add mounted library to library paths
 .libPaths(c("/randomwalk-lib", .libPaths()))
 
 # Install ggplot2 dependencies explicitly from webR repository
 # Use /tmp for installation since it's writable
-eval(parse(text = 'webr::install(c("munsell", "colorspace", "farver", "labeling", "viridisLite", "RColorBrewer", "scales", "tibble", "ggplot2"), lib = "/tmp/webr-libs")'))
+webr::install(c("munsell", "colorspace", "farver", "labeling", "viridisLite",
+                 "RColorBrewer", "scales", "tibble", "ggplot2"),
+               lib = "/tmp/webr-libs")
 
 # Add the tmp library to the path
 .libPaths(c("/tmp/webr-libs", .libPaths()))
@@ -41,7 +46,7 @@ eval(parse(text = 'webr::install(c("munsell", "colorspace", "farver", "labeling"
 library(shiny)
 
 # Load randomwalk from mounted library
-eval(parse(text = "library(randomwalk)"))
+library(randomwalk)
 
 # Define UI
 ui <- fluidPage(

--- a/vignettes/dynamic_broadcasting.qmd
+++ b/vignettes/dynamic_broadcasting.qmd
@@ -1,5 +1,5 @@
 ---
-title: "Dynamic Grid Broadcasting Dashboard"
+title: "Hello Dynamic Grid Broadcasting Dashboard"
 format:
   html:
     code-fold: true
@@ -23,16 +23,21 @@ The dashboard runs entirely in your browser using WebAssembly.
 #| standalone: true
 #| viewerHeight: 900
 
-# Mount WebAssembly file system from GitHub release
-# The wasm-release.yaml workflow builds library.data and attaches to releases
-eval(parse(text = 'webr::mount(mountpoint = "/randomwalk-lib", source = "https://github.com/JohnGavin/randomwalk/releases/download/v0.1.0/library.data")'))
+# Mount WebAssembly file system from local path (deployed to docs/wasm)
+# This avoids CORS issues by using the same origin
+webr::mount(
+  mountpoint = "/randomwalk-lib",
+  source = "../wasm/library.data"
+)
 
 # Add mounted library to library paths
 .libPaths(c("/randomwalk-lib", .libPaths()))
 
 # Install ggplot2 dependencies explicitly from webR repository
 # Use /tmp for installation since it's writable
-eval(parse(text = 'webr::install(c("munsell", "colorspace", "farver", "labeling", "viridisLite", "RColorBrewer", "scales", "tibble", "ggplot2"), lib = "/tmp/webr-libs")'))
+webr::install(c("munsell", "colorspace", "farver", "labeling", "viridisLite",
+                 "RColorBrewer", "scales", "tibble", "ggplot2"),
+               lib = "/tmp/webr-libs")
 
 # Add the tmp library to the path
 .libPaths(c("/tmp/webr-libs", .libPaths()))
@@ -41,7 +46,8 @@ eval(parse(text = 'webr::install(c("munsell", "colorspace", "farver", "labeling"
 library(shiny)
 
 # Load randomwalk from mounted library
-eval(parse(text = "library(randomwalk)"))
+library(randomwalk)
+
 
 # Define UI
 ui <- fluidPage(


### PR DESCRIPTION
This PR addresses critical issues preventing dashboard deployment and execution:

1. **Website Corruption Fixes**:
   - Repaired corrupted code blocks in `dashboard_async.qmd` caused by obfuscation attempts.
   - Updated `webr::mount` calls in all dashboards to use `../wasm/library.data` (relative local path) instead of GitHub Releases URL. This solves the CORS blocking issue for the Shiny app library loading.
   - Added "Hello" to dashboard titles to provide visual verification of successful deployment propagation.

2. **CI/CD Stabilization**:
   - Added `push_to_cachix.sh` to `.Rbuildignore` to resolve the `cp: cannot stat` error during build.
   - Reverted the experimental `nix-ci.yml` caching optimization (dev env push) as it was causing excessive rebuilds on Linux runners and slowing down the workflow.