### PR TITLE
Fix: Optimize Nix CI workflow with caching and timeouts

### DIFF
--- a/.github/workflows/nix-ci.yml
+++ b/.github/workflows/nix-ci.yml
@@ -31,6 +31,7 @@ jobs:
   build-and-cache-package:
     name: Build & Cache Package
     runs-on: ubuntu-latest
+    timeout-minutes: 20
 
     steps:
       - name: Checkout code
@@ -78,6 +79,14 @@ jobs:
           nix-store -qR --include-outputs result | cachix push johngavin
           echo "✓ Package cached successfully"
 
+      - name: Build and Cache Dev Environment
+        run: |
+          echo "Instantiating default-ci.nix environment..."
+          # This builds the full shell environment including R, Quarto, and system tools
+          # We push this to cache so subsequent Linux jobs can just pull it
+          nix-store -qR --include-outputs $(nix-instantiate default-ci.nix) | cachix push johngavin
+          echo "✓ Dev environment cached successfully"
+
       - name: Verify package structure
         run: |
           echo "Package structure:"
@@ -88,6 +97,7 @@ jobs:
     name: R CMD check
     needs: build-and-cache-package
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - name: Checkout code
@@ -135,6 +145,7 @@ jobs:
     name: Run Tests
     needs: build-and-cache-package
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - name: Checkout code
@@ -184,6 +195,7 @@ jobs:
     name: Build pkgdown site
     needs: build-and-cache-package
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     # Only run on pushes to main, not on PRs
     if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/master')
 
@@ -230,7 +242,9 @@ jobs:
   # Job 5: Check nix file generation
   check-nix-generation:
     name: Verify Nix Files
+    needs: build-and-cache-package
     runs-on: ubuntu-latest
+    timeout-minutes: 15
 
     steps:
       - name: Checkout code


### PR DESCRIPTION
This PR addresses the performance and stability issues in the Nix CI workflow:

1.  **Timeouts Added**: Configured `timeout-minutes: 20` for the `build-and-cache-package` job and `timeout-minutes: 15` for all subsequent jobs. This prevents runaway job execution and ensures quicker feedback.
2.  **Linux Environment Caching**: Re-implemented the caching of the full Linux development environment (`default-ci.nix`) in the `build-and-cache-package` job. This was done by adding a step to instantiate and push `default-ci.nix` to `johngavin` Cachix, producing Linux-compatible binaries.
3.  **Job Sequencing**: Ensured all downstream jobs (`r-cmd-check`, `test`, `pkgdown`, `check-nix-generation`) explicitly `needs: build-and-cache-package`. This forces them to wait for the environment to be cached in the first job, allowing them to pull pre-built binaries from Cachix instead of recompiling from source.

This comprehensive update aims to drastically reduce CI runtime, optimize resource usage, and provide faster, more reliable feedback.