### PR TITLE
Fix: Optimize pkgdown job in Nix CI using native R for bslib compatibility (v3)

### DIFF
--- a/.github/workflows/nix-ci.yml
+++ b/.github/workflows/nix-ci.yml
@@ -209,28 +209,29 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Install Nix
-        uses: cachix/install-nix-action@v31
+      - name: Setup R
+        uses: r-lib/actions/setup-r@v2
         with:
-          nix_path: nixpkgs=https://github.com/NixOS/nixpkgs/archive/1482d00f8f658fd443526febba6c9fd9754cb356.tar.gz
+          # Use a specific R version if needed, or default for latest stable
+          # r-version: '4.x' 
+          # This action installs Quarto automatically.
 
-      - name: Configure caches
-        uses: cachix/cachix-action@v14
-        with:
-          name: rstats-on-nix
-
-      - name: Configure johngavin cache
-        uses: cachix/cachix-action@v14
-        with:
-          name: johngavin
-          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
-
+      - name: Install R Dependencies for pkgdown
+        run: |
+          # Install R packages required for pkgdown and vignette rendering in native R environment
+          install.packages(c("pkgdown", "rmarkdown", "knitr", "shinylive", "ggplot2", "dplyr", "targets", "tarchetypes", "logger", "gert"))
+          
       - name: Build pkgdown site
         run: |
-          nix-shell default-ci.nix --run "
-            echo 'Building pkgdown site...'
-            Rscript -e 'pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE)'
-          "
+          echo 'Building pkgdown site in native R environment...'
+          Rscript -e '
+            # Configure git for pkgdown to prevent errors
+            gert::git_config_set("user.name", "github-actions[bot]")
+            gert::git_config_set("user.email", "github-actions[bot]@users.noreply.github.com")
+
+            # Build pkgdown site
+            pkgdown::build_site_github_pages(new_process = FALSE, install = FALSE)
+          '
 
       - name: Deploy to GitHub Pages
         uses: JamesIves/github-pages-deploy-action@v4


### PR DESCRIPTION
This PR addresses the bslib permission denied error encountered during the pkgdown site build:

1.  **Hybrid Workflow for pkgdown**: The `pkgdown` job in `nix-ci.yml` now uses `r-lib/actions/setup-r@v2` to create a native R environment instead of running inside `nix-shell`.
2.  **Native R Package Installation**: Necessary R packages (like `pkgdown`, `shinylive`, `ggplot2`, `gert`, etc.) are installed directly into this native R environment using `install.packages()`.
3.  **Resolves bslib Incompatibility**: This bypasses the read-only file system issues encountered by `bslib` when attempting to copy JavaScript files in the Nix store, which was causing `pkgdown` builds to fail.

This change ensures the `pkgdown` site can be built successfully in CI while maintaining the Nix environment for other jobs like `R CMD check` and `tests`.