### PR TITLE
PERF: Reduce WebR dashboard defaults for better performance (#172)

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: randomwalk
 Type: Package
 Title: Asynchronous Pixel Walking Simulation with Parallel Processing
-Version: 2.1.0
+Version: 2.1.1
 Authors@R:
     person("John", "Gavin", , "john@example.com", role = c("aut", "cre"))
 Description: Implements parallel random walk simulations that create fractal

--- a/R/dev/issues/fix_issue_172_webr_performance.R
+++ b/R/dev/issues/fix_issue_172_webr_performance.R
@@ -1,0 +1,40 @@
+# ==============================================================================
+# Fix Issue #172: WebR dashboard simulation extremely slow (400 steps/sec)
+# Date: 2026-01-15
+# ==============================================================================
+#
+# Problem:
+# - Browser-based simulations in WebR are extremely slow (~400 steps/sec)
+# - Original defaults: 2000 walkers × 5000 steps = 10M potential steps
+# - At 400 steps/sec = potentially 7+ hours for worst case!
+#
+# Root Cause:
+# - WebR/WASM has inherent overhead compared to native R
+# - Matrix operations and R loops are slower in WASM
+# - No parallel processing available in browser
+#
+# Solution:
+# 1. Reduced default parameters for WebR-friendly experience:
+#    - Grid size: max 400 → 200, default 100 → 80
+#    - Walkers: max 5000 → 1000, default 2000 → 200
+#    - Max steps: max 10000 → 2000, default 5000 → 500
+#
+# 2. Added runtime estimate display:
+#    - Shows estimated time based on 400 steps/sec
+#    - Color-coded: green (<1min), orange (1-5min), red (>5min)
+#    - Displays total steps calculation
+#
+# 3. Updated limitations section with recommendations:
+#    - Explicit ~400 steps/sec performance note
+#    - Recommended parameters for browser use
+#    - Suggestion to use native R for larger simulations
+#
+# Files Modified:
+# - vignettes/articles/dashboard_comprehensive.qmd
+# - DESCRIPTION (version bump 2.1.0 → 2.1.1)
+#
+# Testing:
+# - Default params (200 walkers × 500 steps = 100K steps)
+# - At 400 steps/sec = ~4 minutes (reasonable for demo)
+#
+# Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>

--- a/vignettes/articles/dashboard_comprehensive.qmd
+++ b/vignettes/articles/dashboard_comprehensive.qmd
@@ -110,10 +110,10 @@ ui <- fluidPage(
       h4("Simulation Parameters"),
 
       sliderInput("grid_size", "Grid Size:",
-                  min = 20, max = 400, value = 100, step = 20),
+                  min = 20, max = 200, value = 80, step = 20),
 
       sliderInput("n_walkers", "Number of Walkers:",
-                  min = 1, max = 5000, value = 2000, step = 50),
+                  min = 1, max = 1000, value = 200, step = 50),
 
       selectInput("neighborhood", "Neighborhood:",
                   choices = c("4-hood", "8-hood"),
@@ -124,7 +124,13 @@ ui <- fluidPage(
                   selected = "terminate"),
 
       sliderInput("max_steps", "Max Steps per Walker:",
-                  min = 100, max = 10000, value = 5000, step = 100),
+                  min = 100, max = 2000, value = 500, step = 100),
+
+      hr(),
+
+      # Runtime estimate (WebR ~400 steps/sec observed)
+      h5("Estimated Runtime:"),
+      uiOutput("runtime_estimate"),
 
       hr(),
 
@@ -211,9 +217,10 @@ ui <- fluidPage(
                  hr(),
                  h5("Limitations"),
                  tags$ul(
-                   tags$li("Browser: sync sequential only"),
+                   tags$li("Browser: sync sequential only (~400 steps/sec)"),
                    tags$li("First load: 15-30s (downloads)"),
-                   tags$li("Large sims may be slow")
+                   tags$li("Recommended: grid ≤100, walkers ≤500, steps ≤1000"),
+                   tags$li("For larger simulations, use native R with crew")
                  ),
                  hr(),
                  tags$a(href="https://johngavin.github.io/randomwalk/", "Documentation"),
@@ -236,6 +243,35 @@ server <- function(input, output, session) {
   sim_state <- reactiveVal("idle")  # States: idle, running, complete, error
   sim_start_time <- reactiveVal(NULL)
   sim_end_time <- reactiveVal(NULL)
+
+  # Runtime estimate (WebR ~400-500 steps/sec observed in Issue #172)
+  output$runtime_estimate <- renderUI({
+    max_steps <- input$n_walkers * input$max_steps
+    # Conservative estimate: 400 steps/sec for WebR
+    est_seconds <- max_steps / 400
+
+    if (est_seconds < 60) {
+      est_text <- sprintf("~%.0f seconds", est_seconds)
+      color <- "green"
+    } else if (est_seconds < 300) {
+      est_text <- sprintf("~%.1f minutes", est_seconds / 60)
+      color <- "orange"
+    } else {
+      est_text <- sprintf("~%.1f minutes (consider smaller params)", est_seconds / 60)
+      color <- "red"
+    }
+
+    tags$div(
+      style = paste0("color: ", color, "; font-weight: bold;"),
+      est_text,
+      tags$br(),
+      tags$small(style = "color: gray;",
+                 sprintf("(%s walkers × %s steps = %sK steps)",
+                         format(input$n_walkers, big.mark=","),
+                         format(input$max_steps, big.mark=","),
+                         format(round(max_steps/1000), big.mark=",")))
+    )
+  })
 
   # Periodic timer for debug updates and status indicator
   timer <- reactiveTimer(1000)  # Update every second


### PR DESCRIPTION
## Summary

Addresses WebR performance issue where browser simulations were taking hours instead of minutes.

### Changes

**Reduced defaults for WebR-friendly experience:**
| Parameter | Before | After |
|-----------|--------|-------|
| Grid size max | 400 | 200 |
| Grid size default | 100 | 80 |
| Walkers max | 5000 | 1000 |
| Walkers default | 2000 | 200 |
| Max steps max | 10000 | 2000 |
| Max steps default | 5000 | 500 |

**Added runtime estimate:**
- Shows estimated time based on ~400 steps/sec WebR performance
- Color-coded: green (<1min), orange (1-5min), red (>5min with warning)
- Displays total steps calculation

**Updated guidance:**
- Limitations section now shows recommended parameters
- Suggests native R with crew for larger simulations

### Impact

Default simulation: 200 walkers × 500 steps = 100K steps
- Before: up to 10M steps = potentially 7+ hours
- After: 100K steps = ~4 minutes

## Test plan
- [ ] CI passes
- [ ] Test dashboard in browser with default params
- [ ] Verify runtime estimate displays correctly

Closes #172

🤖 Generated with [Claude Code](https://claude.com/claude-code)