### PR TITLE
CI: Simplify deploy-pages to always use pre-built docs (#178)

### DIFF
--- a/.github/workflows/deploy-pages.yaml
+++ b/.github/workflows/deploy-pages.yaml
@@ -1,14 +1,14 @@
 name: Deploy to GitHub Pages
 
-# IMPORTANT: Per 9-step workflow, users should:
+# IMPORTANT: Per 9-step workflow, users MUST:
 # 1. Build locally with targets::tar_make()
 # 2. Commit docs/ directory
 # 3. Push to cachix
 # 4. Push to GitHub
 # 5. This workflow deploys the pre-built docs/
 #
-# The build step below is a FALLBACK for when docs/ is not pre-built.
-# Pre-built deployments are much faster (~30 seconds vs 20+ minutes).
+# This workflow ALWAYS deploys from pre-built docs/ (no CI rebuild).
+# This saves CI quota and ensures fast, predictable deployments.
 
 on:
   push:
@@ -21,50 +21,49 @@ permissions:
   repository-projects: read   # Needed for webR build
 
 jobs:
-  # Check if we can use pre-built docs (fast path)
-  check-prebuilt:
+  # Build webR binaries (needed for Shinylive dashboards)
+  build-webr:
     runs-on: ubuntu-latest
-    outputs:
-      use_prebuilt: ${{ steps.check.outputs.use_prebuilt }}
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build webR binaries
+        uses: r-wasm/actions/build-rwasm@v2
         with:
-          fetch-depth: 2  # Need previous commit to check changes
+          # Note: nanonext/mirai removed - they don't work in WebAssembly anyway
+          # Vignettes run in sync mode (workers=0) in browser
+          packages: local::.
+          repo-path: _site
+          # Use webR v0.4.2 to match Shinylive 0.9.1's R 4.4.1
+          webr-image: ghcr.io/r-wasm/webr:v0.4.2
 
-      - name: Check if docs/ was updated in this commit
-        id: check
-        run: |
-          # Check if docs/index.html exists and was modified
-          if git diff --name-only HEAD~1 HEAD | grep -q "^docs/"; then
-            echo "docs/ was updated - using pre-built site (fast path)"
-            echo "use_prebuilt=true" >> $GITHUB_OUTPUT
-          elif [ -f "docs/index.html" ]; then
-            echo "docs/index.html exists but wasn't updated - checking freshness"
-            # Check if docs is newer than R source
-            DOCS_TIME=$(git log -1 --format=%ct -- docs/)
-            SRC_TIME=$(git log -1 --format=%ct -- R/ _targets.R vignettes/)
-            if [ "$DOCS_TIME" -ge "$SRC_TIME" ]; then
-              echo "docs/ is up-to-date - using pre-built site"
-              echo "use_prebuilt=true" >> $GITHUB_OUTPUT
-            else
-              echo "docs/ is stale - need to rebuild"
-              echo "use_prebuilt=false" >> $GITHUB_OUTPUT
-            fi
-          else
-            echo "No pre-built docs/ - need to build from scratch"
-            echo "use_prebuilt=false" >> $GITHUB_OUTPUT
-          fi
+      - name: Upload webR binaries as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: webr-repo
+          path: _site/
+          retention-days: 1
 
-  # Fast path: Deploy pre-built docs with webR binaries
-  deploy-prebuilt:
+  # Deploy pre-built docs + webR binaries
+  deploy:
     runs-on: ubuntu-latest
-    needs: [check-prebuilt, build-webr]
-    if: needs.check-prebuilt.outputs.use_prebuilt == 'true'
+    needs: build-webr
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - uses: actions/checkout@v4
+
+      - name: Verify pre-built docs exist
+        run: |
+          if [ ! -f "docs/index.html" ]; then
+            echo "ERROR: docs/index.html not found!"
+            echo "You must build locally with targets::tar_make() and commit docs/"
+            exit 1
+          fi
+          echo "Pre-built docs/ found:"
+          ls -la docs/*.html | head -10
 
       - name: Download webR binaries
         uses: actions/download-artifact@v4
@@ -84,190 +83,9 @@ jobs:
           fi
 
           echo "webR binaries merged successfully"
-          ls -la docs/bin/emscripten/contrib/ || echo "Warning: No contrib directory"
+          ls -la docs/bin/emscripten/contrib/ 2>/dev/null || echo "Note: No contrib directory (OK if no WASM packages)"
 
       - name: Upload merged docs
-        uses: actions/upload-pages-artifact@v3
-        with:
-          path: 'docs'
-
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
-
-  # Slow path: Build from scratch (fallback when docs/ not pre-built)
-  build-targets-and-site:
-    needs: check-prebuilt
-    if: needs.check-prebuilt.outputs.use_prebuilt == 'false'
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Install Nix
-        uses: DeterminateSystems/nix-installer-action@main
-
-      - uses: cachix/cachix-action@v15
-        with:
-          name: rstats-on-nix
-
-      - uses: cachix/cachix-action@v15
-        with:
-          name: johngavin
-          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
-
-      - name: Build Nix environment
-        run: |
-          nix-build --quiet default-ci.nix
-
-      - name: Build randomwalk package (for verification and cachix)
-        run: |
-          nix-build --quiet package.nix
-
-      # Cache targets to skip re-running unchanged simulations
-      # This can save 10-20 minutes on incremental builds
-      - name: Cache targets
-        uses: actions/cache@v4
-        with:
-          path: |
-            _targets/meta
-            _targets/objects
-          key: targets-${{ runner.os }}-${{ hashFiles('_targets.R', 'R/**/*.R') }}
-          restore-keys: |
-            targets-${{ runner.os }}-
-
-      - name: Build all targets (simulations + vignettes + pkgdown)
-        run: |
-          nix-shell --quiet default-ci.nix --run "
-            Rscript -e 'targets::tar_make()'
-          "
-          # Verify vignettes were rendered
-          ls -lh vignettes/articles/*.html 2>/dev/null || echo "No vignette HTML files yet"
-          # Verify pkgdown site was built
-          ls -lh docs/*.html 2>/dev/null || echo "No pkgdown HTML files yet"
-
-      - name: Copy rendered vignettes to docs/articles
-        run: |
-          mkdir -p docs/articles
-          cp vignettes/articles/*.html docs/articles/ || true
-          cp -r vignettes/articles/*_files docs/articles/ || true
-          echo \"Vignettes copied to docs/articles/\"
-          ls -la docs/articles/*.html 2>/dev/null || echo \"No HTML files found\"
-
-      - name: Upload pkgdown site as artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: pkgdown-site
-          path: docs/
-          retention-days: 1
-
-  # Second job: Build webR binaries (always runs - needed for both fast and slow paths)
-  build-webr:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Build webR binaries
-        uses: r-wasm/actions/build-rwasm@v2
-        with:
-          # Note: nanonext/mirai removed - they don't work in WebAssembly anyway
-          # Vignettes run in sync mode (workers=0) in browser
-          packages: local::.
-          repo-path: _site
-          # Use webR v0.4.2 to match Shinylive 0.9.1's R 4.4.1
-          webr-image: ghcr.io/r-wasm/webr:v0.4.2
-
-      - name: Debug - Show webR build output structure
-        run: |
-          echo "=== Contents of _site/ after build-rwasm ==="
-          ls -laR _site/ || echo "ERROR: _site/ directory not found"
-          echo ""
-          echo "=== Disk usage of _site/ ==="
-          du -sh _site/* 2>/dev/null || echo "No files in _site/"
-          echo ""
-          echo "=== Looking for PACKAGES files ==="
-          find _site -name "PACKAGES*" -exec echo "Found: {}" \; -exec head -5 {} \; || echo "No PACKAGES files found"
-
-      - name: Upload webR binaries as artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: webr-repo
-          path: _site/
-          retention-days: 1
-
-  # Third job: Deploy pkgdown site + webR binaries together (slow path only)
-  deploy:
-    runs-on: ubuntu-latest
-    needs: [check-prebuilt, build-targets-and-site, build-webr]  # Wait for both builds
-    if: needs.check-prebuilt.outputs.use_prebuilt == 'false'
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-    steps:
-      - name: Download pkgdown site
-        uses: actions/download-artifact@v4
-        with:
-          name: pkgdown-site
-          path: docs/
-
-      - name: Download webR binaries
-        uses: actions/download-artifact@v4
-        with:
-          name: webr-repo
-          path: webr-temp/
-
-      - name: Debug - Show downloaded artifact contents
-        run: |
-          echo "=== Contents of webr-temp/ after download ==="
-          ls -laR webr-temp/ || echo "ERROR: webr-temp/ directory not found"
-          echo ""
-          echo "=== Disk usage of webr-temp/ ==="
-          du -sh webr-temp/* 2>/dev/null || echo "No files in webr-temp/"
-          echo ""
-          echo "=== Looking for bin/ directory ==="
-          find webr-temp -type d -name "bin" -exec echo "Found bin at: {}" \; -exec ls -la {} \; || echo "No bin/ directory found"
-
-      - name: Merge webR binaries into docs
-        run: |
-          # Copy webR repository structure into docs/ directory
-          echo "Merging webR binaries into docs/"
-          cp -r webr-temp/* docs/
-          echo "webR binaries merged successfully"
-
-          # Verify the structure
-          echo "Checking for CRAN-like repository structure:"
-          ls -la docs/bin/ || echo "Warning: No bin/ directory"
-          ls -la docs/bin/emscripten/contrib/ || echo "Warning: No contrib/ directory"
-          find docs/bin -name "PACKAGES" -exec echo "Found: {}" \; || echo "Warning: No PACKAGES file"
-
-          # Create R 4.4 compatibility directory (GitHub Pages doesn't support symlinks)
-          echo "Creating R 4.4 compatibility directory..."
-          if [ -d "docs/bin/emscripten/contrib/4.5" ]; then
-            cp -r docs/bin/emscripten/contrib/4.5 docs/bin/emscripten/contrib/4.4
-            echo "Directory created: 4.4 (copy of 4.5)"
-            ls -la docs/bin/emscripten/contrib/
-          fi
-
-      - name: Debug - Show final docs/ structure before upload
-        run: |
-          echo "=== Top-level docs/ contents ==="
-          ls -la docs/ | head -30
-          echo ""
-          echo "=== docs/bin/ structure (if exists) ==="
-          if [ -d "docs/bin" ]; then
-            tree -L 4 docs/bin/ || find docs/bin -type f -o -type d | head -50
-            echo ""
-            echo "=== File count in docs/bin/ ==="
-            find docs/bin -type f | wc -l
-          else
-            echo "ERROR: docs/bin/ does not exist!"
-          fi
-          echo ""
-          echo "=== Total size of docs/ to be uploaded ==="
-          du -sh docs/
-
-      - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
           path: 'docs'


### PR DESCRIPTION
## Summary
Fixes #178

Simplifies the deploy-pages workflow to **always** deploy from pre-built `docs/` directory:

- **Removed**: Slow path (build-targets-and-site job) that tried to rebuild with targets
- **Removed**: check-prebuilt conditional logic
- **Kept**: webR binary building (needed for Shinylive dashboards)
- **Kept**: Pre-built docs verification and deployment

## Why This Change

The targets rebuild in CI was:
1. Failing intermittently (step 9 failures)
2. Consuming CI quota unnecessarily
3. Redundant since we follow the 9-step workflow (build locally, commit docs/)

## Workflow Now

```
push to main
    → build-webr (compile WASM packages)
    → deploy (verify docs/, merge webR binaries, deploy to Pages)
```

Reduced from ~200 lines to ~95 lines.

## Test Plan
- [ ] CI workflow runs successfully
- [ ] GitHub Pages deploys correctly
- [ ] Shinylive dashboards load in browser

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>