### PR TITLE
FEAT: Add pre-commit hook for automatic nix file regeneration (#78)

### DIFF
--- a/R/setup/nix/install_hooks.R
+++ b/R/setup/nix/install_hooks.R
@@ -1,0 +1,144 @@
+# install_hooks.R
+#
+# Install git hooks for automatic nix file regeneration
+#
+# Usage:
+#   source("R/setup/nix/install_hooks.R")
+#   install_git_hooks()
+#
+# What it does:
+#   Installs the pre-commit hook that automatically regenerates nix files
+#   when DESCRIPTION is modified. This ensures nix files stay in sync.
+
+#' Find package root directory
+#'
+#' Searches upward from current directory to find DESCRIPTION file
+#' @return Path to package root
+#' @keywords internal
+find_package_root <- function() {
+  path <- getwd()
+  while (path != dirname(path)) {
+    if (file.exists(file.path(path, "DESCRIPTION"))) {
+      return(path)
+    }
+    path <- dirname(path)
+  }
+  stop("Could not find package root (no DESCRIPTION file found)")
+}
+
+#' Install git hooks for nix file auto-regeneration
+#'
+#' Copies the pre-commit hook from inst/hooks to .git/hooks and makes it executable.
+#' This hook automatically regenerates nix files when DESCRIPTION changes.
+#'
+#' @param force Logical. If TRUE, overwrite existing hooks (default FALSE)
+#' @return Invisible TRUE on success
+#' @export
+#'
+#' @examples
+#' \dontrun{
+#' install_git_hooks()
+#' }
+install_git_hooks <- function(force = FALSE) {
+  # Find package root (directory containing DESCRIPTION)
+  pkg_root <- find_package_root()
+
+  hook_source <- file.path(pkg_root, "inst", "hooks", "pre-commit")
+  hook_dest <- file.path(pkg_root, ".git", "hooks", "pre-commit")
+
+  # Check source exists
+
+if (!file.exists(hook_source)) {
+    stop("Hook source not found: ", hook_source, "\n",
+         "Please ensure inst/hooks/pre-commit exists")
+  }
+
+  # Check .git directory exists
+  git_dir <- file.path(pkg_root, ".git")
+  if (!dir.exists(git_dir)) {
+    stop("Not a git repository: ", pkg_root)
+  }
+
+  # Create hooks directory if needed
+  hooks_dir <- file.path(git_dir, "hooks")
+  if (!dir.exists(hooks_dir)) {
+    dir.create(hooks_dir)
+  }
+
+  # Check for existing hook
+  if (file.exists(hook_dest) && !force) {
+    message("Pre-commit hook already exists at: ", hook_dest)
+    message("Use install_git_hooks(force = TRUE) to overwrite")
+    return(invisible(FALSE))
+  }
+
+  # Copy hook
+  file.copy(hook_source, hook_dest, overwrite = force)
+
+  # Make executable (Unix only)
+  if (.Platform$OS.type == "unix") {
+    Sys.chmod(hook_dest, mode = "0755")
+  }
+
+  message("Installed pre-commit hook to: ", hook_dest)
+  message("")
+  message("The hook will automatically regenerate nix files when you commit")
+  message("changes to DESCRIPTION. To test it:")
+  message("")
+  message("  1. Make a small change to DESCRIPTION (e.g., add a space)")
+  message("  2. git add DESCRIPTION")
+message("  3. git commit -m 'test hook'")
+  message("  4. Check that package.nix and default-ci.nix were updated")
+  message("")
+
+  invisible(TRUE)
+}
+
+#' Uninstall git hooks
+#'
+#' Removes the pre-commit hook installed by install_git_hooks()
+#'
+#' @return Invisible TRUE on success
+#' @export
+uninstall_git_hooks <- function() {
+  pkg_root <- find_package_root()
+  hook_dest <- file.path(pkg_root, ".git", "hooks", "pre-commit")
+
+  if (!file.exists(hook_dest)) {
+    message("No pre-commit hook found")
+    return(invisible(FALSE))
+  }
+
+  file.remove(hook_dest)
+  message("Removed pre-commit hook: ", hook_dest)
+
+  invisible(TRUE)
+}
+
+#' Check if git hooks are installed
+#'
+#' @return Logical. TRUE if pre-commit hook is installed
+#' @export
+hooks_installed <- function() {
+  pkg_root <- find_package_root()
+  hook_dest <- file.path(pkg_root, ".git", "hooks", "pre-commit")
+
+  if (file.exists(hook_dest)) {
+    message("Pre-commit hook is installed: ", hook_dest)
+    TRUE
+  } else {
+    message("Pre-commit hook is NOT installed")
+    message("Run install_git_hooks() to install")
+    FALSE
+  }
+}
+
+# Print usage if sourced interactively
+if (interactive()) {
+  message("Git hooks installer loaded.")
+  message("")
+  message("Usage:")
+  message("  install_git_hooks()     # Install hooks")
+  message("  uninstall_git_hooks()   # Remove hooks")
+  message("  hooks_installed()       # Check status")
+}

--- a/inst/hooks/pre-commit
+++ b/inst/hooks/pre-commit
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+#
+# pre-commit hook: Auto-regenerate nix files when DESCRIPTION changes
+#
+# Installation:
+#   Rscript -e 'source("R/setup/nix/install_hooks.R"); install_git_hooks()'
+#   OR manually: cp inst/hooks/pre-commit .git/hooks/pre-commit && chmod +x .git/hooks/pre-commit
+#
+# What it does:
+#   1. Detects if DESCRIPTION is staged for commit
+#   2. Regenerates nix files (package.nix, default-ci.nix)
+#   3. Stages the updated nix files
+#   4. Continues with commit (or aborts on failure)
+
+set -e
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Check if DESCRIPTION is staged for commit
+if git diff --cached --name-only | grep -q '^DESCRIPTION$'; then
+    echo -e "${YELLOW}[pre-commit]${NC} DESCRIPTION changed - regenerating nix files..."
+
+    # Check if R is available
+    if ! command -v Rscript &> /dev/null; then
+        echo -e "${RED}[pre-commit]${NC} Error: Rscript not found in PATH"
+        echo "Please ensure you're in the nix shell or have R installed"
+        exit 1
+    fi
+
+    # Check if the generation script exists
+    if [ ! -f "R/setup/nix/generate_nix_files.R" ]; then
+        echo -e "${RED}[pre-commit]${NC} Error: R/setup/nix/generate_nix_files.R not found"
+        exit 1
+    fi
+
+    # Run the nix file generation
+    echo -e "${YELLOW}[pre-commit]${NC} Running generate_all_nix_files()..."
+
+    if Rscript -e 'source("R/setup/nix/generate_nix_files.R"); generate_all_nix_files()' 2>&1; then
+        echo -e "${GREEN}[pre-commit]${NC} Nix files regenerated successfully"
+    else
+        echo -e "${RED}[pre-commit]${NC} Failed to regenerate nix files"
+        echo "Please fix the error and try again"
+        exit 1
+    fi
+
+    # Check if nix files changed
+    NIX_FILES_CHANGED=0
+
+    for nixfile in package.nix default-ci.nix; do
+        if [ -f "$nixfile" ]; then
+            # Check if file has changes (staged or unstaged)
+            if ! git diff --quiet "$nixfile" 2>/dev/null || ! git diff --cached --quiet "$nixfile" 2>/dev/null; then
+                NIX_FILES_CHANGED=1
+                git add "$nixfile"
+                echo -e "${GREEN}[pre-commit]${NC} Staged: $nixfile"
+            fi
+        fi
+    done
+
+    if [ $NIX_FILES_CHANGED -eq 0 ]; then
+        echo -e "${GREEN}[pre-commit]${NC} No nix file changes needed"
+    else
+        echo -e "${GREEN}[pre-commit]${NC} Nix files updated and staged"
+    fi
+fi
+
+# Continue with commit
+exit 0


### PR DESCRIPTION
## Summary
Fixes #78

Adds git hooks that automatically regenerate nix files when DESCRIPTION changes, preventing out-of-sync dependencies.

## New Files

### `inst/hooks/pre-commit`
Shell script that:
1. Detects if DESCRIPTION is staged for commit
2. Runs `generate_all_nix_files()` 
3. Stages updated `package.nix` and `default-ci.nix`
4. Provides colored feedback

### `R/setup/nix/install_hooks.R`
R functions to manage hooks:
- `install_git_hooks()` - Install the pre-commit hook
- `uninstall_git_hooks()` - Remove the hook
- `hooks_installed()` - Check status

## Installation

```r
source("R/setup/nix/install_hooks.R")
install_git_hooks()
```

## How it Works

```
Developer modifies DESCRIPTION
    ↓
git add DESCRIPTION && git commit
    ↓
pre-commit hook triggers
    ↓
generate_all_nix_files() runs
    ↓
Updated nix files auto-staged
    ↓
Commit proceeds with synced files
```

## Benefits

- Prevents forgotten nix regeneration
- No manual steps to remember
- Immediate feedback during development
- CI/CD failures avoided

## Test Plan
- [ ] CI passes
- [ ] Hook installs correctly
- [ ] Hook triggers on DESCRIPTION changes
- [ ] Nix files regenerate and stage properly

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>