### PR TITLE
FIX: Remove crew/mirai from coverage workflow (NNG dependency)

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -41,10 +41,9 @@ jobs:
           extra-packages: |
             any::covr
             any::devtools
-            any::crew
-            any::mirai
-          # Note: nanonext may not be available via RSPM, but crew/mirai provide
-          # the core async functionality needed for coverage
+          # Note: crew/mirai/nanonext removed - they require NNG system library
+          # which is not available on standard Ubuntu runners. The core tests
+          # don't require these packages for coverage measurement.
 
       - name: Generate coverage
         run: |


### PR DESCRIPTION
## Summary

Fixes the failing Code Coverage CI workflow.

## Problem

The coverage workflow was failing at "Setup R dependencies" because:
- `crew` and `mirai` were listed as extra-packages
- These packages depend on `nanonext`
- `nanonext` requires NNG (Nanomsg Next Generation) system library
- NNG is not available on standard Ubuntu runners

## Solution

Removed `crew` and `mirai` from the extra-packages list. These are in the package's Suggests but:
- Not used by the core tests
- Not required for coverage measurement
- The package's main functionality (random walk simulation) doesn't depend on them

## Test Plan
- [ ] CI passes
- [ ] Coverage workflow completes successfully
- [ ] Coverage data is generated and committed

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>