### PR TITLE
CI: Make coverage workflow non-blocking

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -23,6 +23,8 @@ permissions:
 jobs:
   coverage:
     runs-on: ubuntu-latest
+    # Coverage is informational - don't block builds on transient failures
+    continue-on-error: true
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary

Makes the Code Coverage workflow non-blocking by adding `continue-on-error: true`.

## Why

The coverage workflow has transient failures:
- Network/RSPM issues during dependency installation
- These failures are unpredictable and not related to code changes

Since coverage is **informational** (not critical for releases or deployments), the workflow shouldn't block other CI checks.

## What This Changes

- Workflow will still run and report results
- Failures won't appear as PR blockers
- Coverage data will be generated when the workflow succeeds

## Test Plan
- [ ] CI passes (coverage may still fail but won't block)

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>