### PR TITLE
FIX: Skip Suggests dependencies in coverage workflow

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -40,11 +40,12 @@ jobs:
       - name: Setup R dependencies
         uses: r-lib/actions/setup-r-dependencies@v2
         with:
+          # Only install Depends/Imports - skip Suggests which includes
+          # nanonext/crew/mirai that require NNG system library
+          dependencies: '"hard"'
           extra-packages: |
             any::covr
             any::devtools
-          # Note: crew/mirai/nanonext removed - they require NNG system library
-          # which is not available on standard Ubuntu runners.
 
       - name: Generate coverage
         run: |


### PR DESCRIPTION
## Summary
- Fixes the Code Coverage workflow which was failing because `setup-r-dependencies` installs ALL dependencies including Suggests
- The Suggests section in DESCRIPTION includes `nanonext`, `crew`, and `mirai` which require the NNG system library not available on Ubuntu runners

## Changes
- Added `dependencies: '"hard"'` to only install Depends, Imports, and LinkingTo (skipping Suggests)
- `covr` and `devtools` are still installed via `extra-packages`

## Test plan
- [ ] Wait for CI to pass
- [ ] Verify coverage workflow runs successfully after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)