### PR TITLE
FEAT: Add non-blocking statistics display with historical slider

### DIFF
--- a/inst/shiny/dashboard/app.R
+++ b/inst/shiny/dashboard/app.R
@@ -14,6 +14,29 @@ library(randomwalk)
 ui <- fluidPage(
   titlePanel("Random Walk Simulation Dashboard"),
 
+  # Custom CSS for timer and progress display
+  tags$head(
+    tags$style(HTML("
+      .progress-timer {
+        font-size: 24px;
+        font-weight: bold;
+        color: #337ab7;
+        text-align: center;
+        padding: 20px;
+        background: #f5f5f5;
+        border-radius: 8px;
+        margin-bottom: 15px;
+      }
+      .snapshot-info {
+        font-size: 14px;
+        color: #666;
+        text-align: center;
+        margin-bottom: 10px;
+      }
+      .btn-primary { margin-bottom: 10px; }
+    "))
+  ),
+
   sidebarLayout(
     sidebarPanel(
       width = 3,
@@ -38,6 +61,12 @@ ui <- fluidPage(
 
       hr(),
 
+      # Snapshot interval control
+      sliderInput("snapshot_pct", "Snapshot every X% of walkers:",
+                  min = 10, max = 50, value = 25, step = 5),
+
+      hr(),
+
       actionButton("run_sim", "Run Simulation",
                    class = "btn-primary", width = "100%"),
 
@@ -48,6 +77,30 @@ ui <- fluidPage(
 
     mainPanel(
       width = 9,
+
+      # Progress timer display (shown during simulation)
+      conditionalPanel(
+        condition = "output.is_running",
+        div(class = "progress-timer",
+          textOutput("timer_display", inline = TRUE)
+        )
+      ),
+
+      # Snapshot slider (shown after simulation with multiple snapshots)
+      conditionalPanel(
+        condition = "output.has_snapshots",
+        wellPanel(
+          div(class = "snapshot-info",
+            textOutput("snapshot_info", inline = TRUE)
+          ),
+          sliderInput("snapshot_slider", "View Historical Snapshot:",
+                      min = 1, max = 1, value = 1, step = 1, width = "100%"),
+          div(style = "text-align: center;",
+            actionButton("play_snapshots", "Play", class = "btn-sm"),
+            actionButton("stop_snapshots", "Stop", class = "btn-sm")
+          )
+        )
+      ),
 
       tabsetPanel(
         id = "output_tabs",
@@ -74,7 +127,14 @@ ui <- fluidPage(
                  tableOutput("walker_table"),
                  hr(),
                  h4("Grid Information"),
-                 verbatimTextOutput("grid_info"))
+                 verbatimTextOutput("grid_info")),
+
+        tabPanel("Progress History",
+                 br(),
+                 h4("Coverage Over Time"),
+                 plotOutput("progress_plot", height = "400px"),
+                 hr(),
+                 tableOutput("snapshots_table"))
       )
     )
   )
@@ -82,6 +142,17 @@ ui <- fluidPage(
 
 # Server
 server <- function(input, output, session) {
+
+  # Reactive values for state management
+  rv <- reactiveValues(
+    is_running = FALSE,
+    start_time = NULL,
+    elapsed_time = 0,
+    snapshots = list(),
+    current_snapshot = 1,
+    final_result = NULL,
+    playing = FALSE
+  )
 
   # Update max walkers based on grid size
   observe({
@@ -91,6 +162,14 @@ server <- function(input, output, session) {
                      value = min(input$n_walkers, max_walkers))
   })
 
+  # Timer update (every second when running)
+  observe({
+    invalidateLater(1000, session)
+    if (rv$is_running && !is.null(rv$start_time)) {
+      rv$elapsed_time <- as.numeric(difftime(Sys.time(), rv$start_time, units = "secs"))
+    }
+  })
+
   # Reset button
   observeEvent(input$reset, {
     updateSliderInput(session, "grid_size", value = 20)
@@ -98,38 +177,211 @@ server <- function(input, output, session) {
     updateSelectInput(session, "neighborhood", selected = "4-hood")
     updateSelectInput(session, "boundary", selected = "terminate")
     updateSliderInput(session, "max_steps", value = 10000)
+    updateSliderInput(session, "snapshot_pct", value = 25)
+    rv$snapshots <- list()
+    rv$final_result <- NULL
+    rv$current_snapshot <- 1
   })
 
-  # Run simulation using package function
-  sim_result <- eventReactive(input$run_sim, {
-    withProgress(message = 'Running simulation...', {
-      result <- randomwalk::run_simulation(
-        grid_size = input$grid_size,
-        n_walkers = input$n_walkers,
+  # Run simulation with progressive snapshots
+  observeEvent(input$run_sim, {
+    # Start timer
+    rv$is_running <- TRUE
+    rv$start_time <- Sys.time()
+    rv$elapsed_time <- 0
+    rv$snapshots <- list()
+
+    # Calculate snapshot intervals
+    n_walkers <- input$n_walkers
+    snapshot_interval <- max(1, floor(n_walkers * input$snapshot_pct / 100))
+    snapshot_points <- seq(snapshot_interval, n_walkers, by = snapshot_interval)
+    if (!(n_walkers %in% snapshot_points)) {
+      snapshot_points <- c(snapshot_points, n_walkers)
+    }
+
+    # Initialize grid
+    grid_size <- input$grid_size
+    grid <- matrix(FALSE, nrow = grid_size, ncol = grid_size)
+    all_walker_paths <- list()
+
+    withProgress(message = 'Running simulation...', value = 0, {
+      for (i in 1:n_walkers) {
+        # Run single walker
+        walker_result <- randomwalk::simulate_single_walker(
+          grid = grid,
+          grid_size = grid_size,
+          neighborhood = input$neighborhood,
+          boundary = input$boundary,
+          max_steps = input$max_steps
+        )
+
+        # Update grid with walker path
+        for (j in 1:nrow(walker_result$path)) {
+          pos <- walker_result$path[j, ]
+          if (pos[1] >= 1 && pos[1] <= grid_size &&
+              pos[2] >= 1 && pos[2] <= grid_size) {
+            grid[pos[1], pos[2]] <- TRUE
+          }
+        }
+
+        all_walker_paths[[i]] <- walker_result
+
+        # Capture snapshot at interval
+        if (i %in% snapshot_points) {
+          snapshot <- list(
+            walker_count = i,
+            percentage = round(100 * i / n_walkers),
+            grid = grid,
+            black_pixels = sum(grid),
+            black_percentage = 100 * sum(grid) / (grid_size * grid_size),
+            timestamp = Sys.time(),
+            walker_paths = all_walker_paths
+          )
+          rv$snapshots <- c(rv$snapshots, list(snapshot))
+
+          # Update slider max
+          updateSliderInput(session, "snapshot_slider",
+                           max = length(rv$snapshots),
+                           value = length(rv$snapshots))
+        }
+
+        # Update progress
+        incProgress(1/n_walkers, detail = sprintf("Walker %d/%d", i, n_walkers))
+      }
+    })
+
+    # Create final result object
+    rv$final_result <- list(
+      grid = grid,
+      walker_paths = all_walker_paths,
+      parameters = list(
+        grid_size = grid_size,
+        n_walkers = n_walkers,
         neighborhood = input$neighborhood,
         boundary = input$boundary,
         max_steps = input$max_steps
+      ),
+      statistics = list(
+        grid_size = grid_size,
+        black_pixels = sum(grid),
+        black_percentage = 100 * sum(grid) / (grid_size * grid_size),
+        total_walkers = n_walkers,
+        completed_walkers = length(all_walker_paths),
+        total_steps = sum(sapply(all_walker_paths, function(w) nrow(w$path)))
       )
-      result
-    })
+    )
+
+    # Stop timer
+    rv$is_running <- FALSE
+    rv$current_snapshot <- length(rv$snapshots)
   })
 
-  # Grid plot using package function
+  # Snapshot slider change
+  observeEvent(input$snapshot_slider, {
+    rv$current_snapshot <- input$snapshot_slider
+  })
+
+  # Play button - animate through snapshots
+  observeEvent(input$play_snapshots, {
+    rv$playing <- TRUE
+    rv$current_snapshot <- 1
+  })
+
+  # Stop button
+  observeEvent(input$stop_snapshots, {
+    rv$playing <- FALSE
+  })
+
+  # Auto-advance when playing
+  observe({
+    if (rv$playing && length(rv$snapshots) > 0) {
+      invalidateLater(500, session)  # 500ms between frames
+      isolate({
+        if (rv$current_snapshot < length(rv$snapshots)) {
+          rv$current_snapshot <- rv$current_snapshot + 1
+          updateSliderInput(session, "snapshot_slider", value = rv$current_snapshot)
+        } else {
+          rv$playing <- FALSE
+        }
+      })
+    }
+  })
+
+  # Output: is_running (for conditional panel)
+  output$is_running <- reactive({
+    rv$is_running
+  })
+  outputOptions(output, "is_running", suspendWhenHidden = FALSE)
+
+  # Output: has_snapshots (for conditional panel)
+  output$has_snapshots <- reactive({
+    length(rv$snapshots) > 1
+  })
+  outputOptions(output, "has_snapshots", suspendWhenHidden = FALSE)
+
+  # Timer display
+  output$timer_display <- renderText({
+    if (rv$is_running) {
+      sprintf("Running... %.1f seconds", rv$elapsed_time)
+    } else {
+      ""
+    }
+  })
+
+  # Snapshot info
+  output$snapshot_info <- renderText({
+    if (length(rv$snapshots) > 0 && rv$current_snapshot <= length(rv$snapshots)) {
+      snap <- rv$snapshots[[rv$current_snapshot]]
+      sprintf("Snapshot %d/%d: %d walkers (%d%%) - Coverage: %.1f%%",
+              rv$current_snapshot, length(rv$snapshots),
+              snap$walker_count, snap$percentage, snap$black_percentage)
+    } else {
+      ""
+    }
+  })
+
+  # Get current display result (either snapshot or final)
+  current_result <- reactive({
+    if (length(rv$snapshots) > 0 && rv$current_snapshot <= length(rv$snapshots)) {
+      snap <- rv$snapshots[[rv$current_snapshot]]
+      # Create result object from snapshot
+      list(
+        grid = snap$grid,
+        walker_paths = snap$walker_paths,
+        parameters = rv$final_result$parameters,
+        statistics = list(
+          grid_size = nrow(snap$grid),
+          black_pixels = snap$black_pixels,
+          black_percentage = snap$black_percentage,
+          total_walkers = snap$walker_count,
+          completed_walkers = snap$walker_count,
+          total_steps = sum(sapply(snap$walker_paths, function(w) nrow(w$path)))
+        )
+      )
+    } else {
+      rv$final_result
+    }
+  })
+
+  # Grid plot using current snapshot/result
   output$grid_plot <- renderPlot({
-    req(sim_result())
-    randomwalk::plot_grid(sim_result())
+    result <- current_result()
+    req(result)
+    randomwalk::plot_grid(result)
   })
 
-  # Paths plot using package function
+  # Paths plot using current snapshot/result
   output$paths_plot <- renderPlot({
-    req(sim_result())
-    randomwalk::plot_walker_paths(sim_result())
+    result <- current_result()
+    req(result)
+    randomwalk::plot_walker_paths(result)
   })
 
   # Statistics
   output$stats_text <- renderText({
-    req(sim_result())
-    stats <- sim_result()$statistics
+    result <- current_result()
+    req(result)
+    stats <- result$statistics
     paste(
       sprintf("Black Pixels: %d (%.2f%%)",
               stats$black_pixels, stats$black_percentage),
@@ -142,8 +394,8 @@ server <- function(input, output, session) {
 
   # Parameters table
   output$params_table <- renderTable({
-    req(sim_result())
-    result <- sim_result()
+    result <- current_result()
+    req(result)
     params <- result$parameters
     data.frame(
       Parameter = c("Grid Size", "Walkers", "Neighborhood", "Boundary", "Max Steps"),
@@ -159,22 +411,22 @@ server <- function(input, output, session) {
 
   # Walker table
   output$walker_table <- renderTable({
-    req(sim_result())
-    result <- sim_result()
+    result <- current_result()
+    req(result)
 
     walker_data <- data.frame(
       Walker = seq_along(result$walker_paths),
-      Steps = sapply(result$walker_paths, function(p) nrow(p)),
-      Final_X = sapply(result$walker_paths, function(p) p[nrow(p), 1]),
-      Final_Y = sapply(result$walker_paths, function(p) p[nrow(p), 2])
+      Steps = sapply(result$walker_paths, function(p) nrow(p$path)),
+      Final_X = sapply(result$walker_paths, function(p) p$path[nrow(p$path), 1]),
+      Final_Y = sapply(result$walker_paths, function(p) p$path[nrow(p$path), 2])
     )
     walker_data
   })
 
   # Grid info
   output$grid_info <- renderText({
-    req(sim_result())
-    result <- sim_result()
+    result <- current_result()
+    req(result)
     stats <- result$statistics
     grid_size <- stats$grid_size
 
@@ -186,6 +438,46 @@ server <- function(input, output, session) {
       sprintf("White pixels: %d",
               grid_size * grid_size - stats$black_pixels),
       sep = "\n"
+    )
+  })
+
+  # Progress plot - coverage over time
+  output$progress_plot <- renderPlot({
+    req(length(rv$snapshots) > 0)
+
+    progress_data <- data.frame(
+      walker_pct = sapply(rv$snapshots, function(s) s$percentage),
+      coverage_pct = sapply(rv$snapshots, function(s) s$black_percentage)
+    )
+
+    plot(progress_data$walker_pct, progress_data$coverage_pct,
+         type = "b", pch = 19, col = "steelblue",
+         xlab = "Walkers Completed (%)",
+         ylab = "Grid Coverage (%)",
+         main = "Coverage Progress During Simulation",
+         xlim = c(0, 100),
+         ylim = c(0, max(progress_data$coverage_pct) * 1.1))
+
+    # Highlight current snapshot
+    if (rv$current_snapshot <= nrow(progress_data)) {
+      points(progress_data$walker_pct[rv$current_snapshot],
+             progress_data$coverage_pct[rv$current_snapshot],
+             pch = 19, col = "red", cex = 2)
+    }
+
+    grid()
+  })
+
+  # Snapshots summary table
+  output$snapshots_table <- renderTable({
+    req(length(rv$snapshots) > 0)
+
+    data.frame(
+      Snapshot = seq_along(rv$snapshots),
+      Walkers = sapply(rv$snapshots, function(s) s$walker_count),
+      `Walkers %` = sapply(rv$snapshots, function(s) s$percentage),
+      `Black Pixels` = sapply(rv$snapshots, function(s) s$black_pixels),
+      `Coverage %` = sapply(rv$snapshots, function(s) round(s$black_percentage, 2))
     )
   })
 }


### PR DESCRIPTION
## Summary
Enhanced dashboard with progressive rendering and snapshot playback capabilities.

Closes #57

## New Features

### UI Additions
- **Timer display** during simulation (shows elapsed time in seconds)
- **Snapshot interval control** - capture snapshots every 10-50% of walkers
- **Historical slider** - scrub through past snapshots after simulation
- **Play/Stop buttons** - animated playback through snapshots
- **Progress History tab** - coverage over time plot with snapshots table

### Technical Implementation
- `reactiveValues` for state management (is_running, snapshots, playing, etc.)
- `invalidateLater()` for timer updates (every 1 second)
- Configurable snapshot intervals (default 25%)
- Automatic slider updates as snapshots are captured
- 500ms animation frame rate for playback

## Screenshots
*Run simulation to see timer → Complete → Use slider/play to replay*

## Test plan
- [ ] CI passes
- [ ] Dashboard loads in browser
- [ ] Timer displays during simulation
- [ ] Snapshots captured at intervals
- [ ] Slider allows reviewing historical snapshots
- [ ] Play button animates through snapshots

🤖 Generated with [Claude Code](https://claude.com/claude-code)