### PR TITLE
fix(ci): add qpdf to CI nix env (fixes pre-existing R-CMD-check WARNING)

### DIFF
--- a/default-ci.nix
+++ b/default-ci.nix
@@ -49,6 +49,7 @@ let
       glibcLocales
       nix
       pandoc
+      qpdf
       quarto
       R
       which;

--- a/default.R
+++ b/default.R
@@ -49,6 +49,7 @@ system_pkgs <- c(
   "gh",          # GitHub CLI
   "quarto",
   "pandoc",
+  "qpdf",        # needed for R CMD check PDF size-reduction check
   "tree"
 ) |>
   unique() |>


### PR DESCRIPTION
## Summary
- CI's `r-cmd-check.yaml` runs `devtools::check(error_on = "warning", ...)` inside `nix-shell default-ci.nix`, and has been failing since 2026-05-06 with:
  ```
  WARNING: 'qpdf' is needed for checks on size reduction of PDFs
  ```
- `qpdf` was missing from the CI nix environment, so R CMD check could not run the PDF-size-reduction check and emitted a warning, which `error_on = "warning"` escalates to a failure.
- Added `qpdf` to `default-ci.nix`'s `system_packages` (hand-edited — there is no committed rix generator for this file's CI-specific variable set).
- Also added `qpdf` to `default.R`'s `system_pkgs` so the dev-environment source of truth (and any future regeneration) stays in sync.

## Test plan
- [ ] CI run of `r-cmd-check.yaml` on this PR passes without the `qpdf` warning
- [ ] `nix-shell default-ci.nix --run "which qpdf"` resolves inside CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)