### PR TITLE
ci(webr): pin build-rwasm to v3.0.2 SHA — fix res_one_row_df resolver failure (#212)

### DIFF
--- a/.github/workflows/build-rwasm.yml
+++ b/.github/workflows/build-rwasm.yml
@@ -19,7 +19,10 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Build webR binaries
-        uses: r-wasm/actions/build-rwasm@v2
+        # Pinned to v3.0.2 (SHA): v2 pulled rwasm@HEAD each run, whose pkgdepends
+        # resolver aborts on `local::.` with `res_one_row_df: nrow(out) must equal 1`.
+        # v3 bakes a pinned rwasm into the action image. See randomwalk#212.
+        uses: r-wasm/actions/build-rwasm@0f8493df20b6b47d3621f16be81218926a09dad1 # v3.0.2
         with:
           packages: "local::."
           repo-path: _site

--- a/.github/workflows/deploy-pages.yaml
+++ b/.github/workflows/deploy-pages.yaml
@@ -30,7 +30,10 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Build webR binaries
-        uses: r-wasm/actions/build-rwasm@v2
+        # Pinned to v3.0.2 (SHA): v2 pulled rwasm@HEAD each run, whose pkgdepends
+        # resolver aborts on `local::.` with `res_one_row_df: nrow(out) must equal 1`.
+        # v3 bakes a pinned rwasm into the action image. See randomwalk#212.
+        uses: r-wasm/actions/build-rwasm@0f8493df20b6b47d3621f16be81218926a09dad1 # v3.0.2
         with:
           # Note: nanonext/mirai removed - they don't work in WebAssembly anyway
           # Vignettes run in sync mode (workers=0) in browser


### PR DESCRIPTION
Fixes #212.

## What
Pin `r-wasm/actions/build-rwasm` from `@v2` to the **v3.0.2** immutable SHA
(`0f8493df20b6b47d3621f16be81218926a09dad1`) in both `build-rwasm.yml` and the
`build-webr` job of `deploy-pages.yaml`.

## Why
`build-webr` has **never** passed (8 failures since 2026-04). Root cause: `@v2`'s
`code.R` runs `pak::pak("r-wasm/rwasm")` at runtime → pulls **`rwasm@HEAD`** each
run (logs: `rwasm 0.3.0.9000` @ `9d0130d`), whose `pkgdepends` resolver aborts on
`local::.`:

```
Error in "res_one_row_df(entries)" : ! `nrow(out)` must equal `1`.
```

v3's `code.R` removed that runtime install and bakes a **pinned** rwasm into the
action image — so pinning to v3.0.2 pins the toolchain. One-variable change;
`webr-image` pins left as-is.

Ruled out (verified): missing dependency (all five Imports present in
`repo.r-wasm.org` contrib/4.4 & 4.5) and webR version (fails identically on
`v0.4.2` and `main`).

## Verification
CI-only — the webR docker toolchain can't be reproduced locally. **Merge when:**
`build-webr` goes green and `_site/bin/emscripten/contrib/` is populated.
If it still fails, fall back to an inline `docker run` pinning both `pak` and a
released `rwasm` tag, or file upstream at r-wasm/rwasm.

## Impact if wrong
None worse than today — deploy is already green and unblocked (binary merge is
guarded by `if: needs.build-webr.result == 'success'`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)